### PR TITLE
Clarify that a card's source is the primary source of guidance for the decision support

### DIFF
--- a/source/includes/_cds_services.md
+++ b/source/includes/_cds_services.md
@@ -237,7 +237,7 @@ Field | Description
 `summary` | *string*. one-sentence, <140-character summary message for display to the user inside of this card.
 `detail` | *string*.  optional detailed information to display, represented in Markdown. (For non-urgent cards, the EHR may hide these details until the user clicks a link like "view more details...".) 
 `indicator` | *string*.  urgency/importance of what this card conveys. Allowed values, in order of increasing urgency, are: `success`, `info`, `warning`, `hard-stop`. The EHR can use this field to help make UI display decisions such as sort order or coloring. The value `hard-stop` indicates that the workflow should not be allowed to proceed. 
-`source` | *string*. grouping structure for the **Source** of the information displayed on this card.
+`source` | *object*. grouping structure for the **Source** of the information displayed on this card. The source should be the primary source of guidance for the decision support the card represents.
 <nobr>`suggestions`</nobr> | *array* of **Suggestions**, which allow a service to suggest a set of changes in the context of the current activity (e.g.  changing the dose of the medication currently being prescribed, for the `medication-prescribe` activity)
 `links` | *array* of **Links**, which allow a service to suggest a link to an app that the user might want to run for additional information or to help guide a decision.
 


### PR DESCRIPTION
Additionally, fixed a typo to show that the source is an object, not a string in the JSON. This address the issue noted in #19.

@robs16, @robcz, & @jmandel - is this change to all of your liking?