### PR TITLE
Add proposed governance and code of conduct document

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting any member of the Project Management Committee. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -23,7 +23,6 @@
 - [Communication](#communication)
 - [Code of Conduct](#code-of-conduct)
 - [Licensing](#licensing)
-- [Outstanding Questions](#outstanding-questions)
 
 ## Overview
 
@@ -176,20 +175,3 @@ If you encounter any violation of these terms, please contact any member of the 
 ## Licensing
 
 All code is licensed under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). All documentation, including the specification itself, is licensed under the [Creative Commons Attribution 4.0 International license (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/).
-
-## Outstanding Questions
-
-### Contributor license agreement (CLA)
-
-A [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) is an important document for large open source projects.
-
-CLAs are not without their challenges:
-- We need to determine the actual CLA text. This will likely require lawyers. To aid with this, http://contributoragreements.org/ exists to allow you to generate a CLA by simply answering some questions.
-- CLAs introduce a barrier to contributors whom may be reluctant to sign a legal document. For contributors that work for an entity/company, they often must get permission from their company to sign any CLAs
-- We need to enforce and maintain our CLAs. Thankfully, free and open-source services like https://cla-assistant.io/ exist to handle this.
-
-If a CLA is not adopted upfront, it is problematic to introduce a CLA at a later date.
-
-### Trademark
-
-Once we determine trademark ownership, we should link to a trademark usage document.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,195 @@
+# CDS Hooks Governance
+
+- [Overview](#overview)
+- [Roles](#roles)
+   - [Project Management Committee](#project-management-committee)
+   - [Committers](#committers)
+   - [PMC Chair](#pmc-chair)
+   - [Contributors](#contributors)
+   - [Implementers](#implementers)
+   - [The Community](#the-community)
+- [Contributions](#contributions)
+  - [Master branch](#master-branch)
+  - [Feature branches](#feature-branches)
+  - [Forks](#forks)
+- [Voting and Consensus](#voting-and-consensus)
+  - [Approve](#1-approve)
+  - [Abstain](#expressionless-abstain)
+  - [Request changes](#-1-request-changes)
+  - [Consensus](#consensus)
+- [Releases](#releases)
+  - [Versioning](#versioning)
+  - [Scope & Feedback](#scope--feedback)
+- [Communication](#communication)
+- [Code of Conduct](#code-of-conduct)
+- [Licensing](#licensing)
+- [Outstanding Questions](#outstanding-questions)
+
+## Overview
+
+CDS Hooks is a standard for vendor agnostic remote decision support.
+
+The CDS Hooks organization produces an API and related projects that are driven by a community of individuals with varying backgrounds. This document outlines the governance model and consensus driven process by which this community works to ensure we all are operating with the same understanding and expectations. This helps keep our community healthy and happy.
+
+Care has been taken to separate the development process we follow from the tools. With that being said, our use of Github certainly has a great influence in how we've defined this process.
+
+## Roles
+
+### Committers
+
+The committers are individuals who are recognized by merit and have a demonstrated history of contributions and commitment to the project. These individuals have write access to the codebase and are collectively responsible for the project. This includes project direction and scope, accepting contributions, and cultivating the community.
+
+The current committers on the project are:
+
+- [Kevin Shekleton](https://github.com/kpshek) (PMC Chair)
+- [Josh Mandel](https://github.com/jmandel)
+- [Matt Berther](https://github.com/mattberther)
+- [Isaac Vetter](https://github.com/isaacvetter)
+- [Bryn Rhodes](https://github.com/brynrhodes)
+
+
+### Project Management Committee
+
+Members of the PMC are committers who are also responsible for governing the CDS Hooks project. The PMC has primary responsibility for development of the CDS Hooks community. This includes evangelism, organizing Connectathons, and other forms of community building. The PMC also reports progress to the community and defines target feature sets for releases.
+
+The PMC also is responsible for the project governance and process (including this policy).
+
+The current PMC members are:
+
+- [Kevin Shekleton](https://github.com/kpshek) (PMC Chair)
+- [Josh Mandel](https://github.com/jmandel)
+- [Matt Berther](https://github.com/mattberther)
+- [Isaac Vetter](https://github.com/isaacvetter)
+- [Bryn Rhodes](https://github.com/brynrhodes)
+
+
+### PMC Chair
+
+The PMC Chair is a PMC member and committer who takes on the primary responsibility of ensuring the health of the project and community. The PMC Chair Additionally, the PMC Chair maintains logistical resources such as the domain name, hosting resources, and mailing list.
+
+The current PMC Chair is [Kevin Shekleton](https://github.com/kpshek)
+
+### Contributors
+
+Anyone who has submitted a change to any code or documentation that was successfully accepted is considered a contributor. Each contributor will be recognized in the commit log as well as in the CONTRIBUTORS.md file associated with the project.
+
+### Implementers
+
+Implementers are those who have implemented the CDS Hooks API. Such implementations can be done locally, in a test environment, or in a production system.
+
+### The Community
+
+The community refers to the collective set of individuals and parties contributing to, implementing, or following the CDS Hooks project.
+
+## Accepting New Committers and PMC Members
+
+Any existing committer may nominate a contributor as a new committer on the project. The nominee should have a demonstrated history of contributions and commitment. Contributions can come in many forms such as code, issues, documentation, and community engagement. A nominee must receive a unanimous vote from the PMC. Upon being accepted, the PMC Chair will grant the nominee write access to the CDS Hooks repositories and announce the new committer to the mailing list.
+
+Any PMC member may nominate a current committer to the join the PMC. The nominee should have a demonstrated history leadership in support of the community, and must receive a unanimous vote from the PMC.
+
+## Contributions
+
+Anyone is welcome to contribute to the project. All contributions are public and associated to the individual(s) submitting the change.
+
+### Master branch
+
+The master branch must be kept in a releasable state.
+
+Trivial changes may be committed directly to a repository. Changes deemed trivial are things like small documentation typos, ecosystem changes (eg, CI configuration, linting rules), etc. Obviously, *trivial* is subjective and anyone is welcome to comment directly on such changes or open an issue regarding them.
+
+All other changes must be reviewed by the committers. This includes contributions from the community (contributors) as well as the current committers. We use [Github pull requests](https://help.github.com/articles/about-pull-requests/) and [Github pull request reviews](https://help.github.com/articles/about-pull-request-reviews/) to manage reviewing and merging the proposed changes.
+
+For small changes, at least one committer must approve the change. If a committer was the author of the change being reviewed, the approval must come from a different committer. For large, significant, or breaking changes, the committers must reach consensus on the change. Like *trivial*, the notion of *small* and *large* are subjective terms. However, a breaking change should be clear and unambiguous. Note that the size of the contribution does not determine whether the change requires just one approval or consensus. Rather, the impact of the change reflects the type of review required. For instance, the addition of a single optional field to the API would be considered a significant change and would warrant consensus amongst the committers.
+
+API changes are scrutinized far more closely than that of documentation or related code projects (like sample projects, test harnesses, etc). As such, API changes are always considered significant and require consensus from the committers.
+
+### Feature branches
+
+Committers should use feature branches to work on in-progress features and changes. Committers may commit directly to feature branches at any time and without prior review.
+
+Committers can submit a pull request from their feature branch to the master branch for review.
+
+### Forks
+
+As contributors do not have write access to the repository, their contributions must be done from personal forks.
+
+Contributors can submit a pull request from their fork to the upstream master branch for review.
+
+## Voting and Consensus
+
+Anyone is welcome to comment on proposed changes. This includes expressing their opinion on why a proposed change should or should not be approved. Ultimately, committers make the final determination on accepting a proposed change.
+
+Committers should seek out the opinions and experiences from the broader community. It is the committers responsibility to balance the feedback from the community along with their own opinions and experiences.
+
+Committers must express their votes as:
+
+### :+1: Approve
+
+The change is approved as proposed.
+
+### :expressionless: Abstain
+
+Abstentions can be explicit or implicit. An explicit abstain vote is an indication that voter does not have feelings one way or the other on the change. An implicit abstain vote is when no vote is received and does not imply feelings on the change.
+
+Committers are discouraged from explicit or implicit abstentions when possible.
+
+### :-1: Request changes
+
+These votes ask the author to make alterations to their proposed change. This type of vote **must** clearly articulate the reasoning behind the vote and when possible, concrete details of the requested changes.
+
+### Consensus
+
+Consensus is defined as a general agreement between the committers. Note that consensus does not indicate a unanimous agreement between the committers, nor does it indicate a particular majority size.
+
+At this time, consensus is purposely defined as-is and is left to the best judgment of the committers.
+
+## Releases
+
+### Versioning
+
+All projects shall use [semantic versioning](http://semver.org/). Any committer can propose a release and requires the PMC to vote and reach consensus on a release. [Github milestones](https://help.github.com/articles/about-milestones/) are used to associate issues to a particular release.
+
+### Scope & Feedback
+
+For the API and specification, major and minor releases should be managed with a previously communicated intended scope. This helps frame upcoming releases to all stakeholders and set expectations. When the scope of a such releases are determined and a release timeframe is known, the PMC Chair is responsible for announcing plans for upcoming releases to solicit feedback from the community. These release feedback periods will vary depending on the scope of the release and should be of a sufficient length to allow the community to participate.
+
+Fix releases of the API and specification contain bug fixes which do not warrant delay until a minor release. As such, fix releases often are not planned or have little prior planning and may not allow for similar release feedback periods.
+
+The PMC Chair is responsible for announcing releases to the community via the mailing list.
+
+## Communication
+
+Communication should be done in an open and public manner. We leverage many different channels for open communication such as:
+
+- [Mailing list](https://groups.google.com/forum/#!forum/cds-hooks)
+- [Chat](https://chat.fhir.org/)
+- [Github Issues](https://github.com/cds-hooks)
+
+Sometimes, communication occurs outside of these public channels and this is okay; however, committers must summarize any private discussions and any decisions resulting from them in a public channel.
+
+## Code of Conduct
+
+In support of a healthy and inclusive community, we use and enforce a [code of conduct](./CODE_OF_CONDUCT.md) for all members of our community, including committers. Our code of conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org/).
+
+If you encounter any violation of these terms, please contact any member of the PMC. All reports will be kept in strict confidence and dealt with promptly.
+
+## Licensing
+
+All code is licensed under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). All documentation, including the specification itself, is licensed under the [Creative Commons Attribution 4.0 International license (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/).
+
+## Outstanding Questions
+
+### Contributor license agreement (CLA)
+
+A [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) is an important document for large open source projects.
+
+CLAs are not without their challenges:
+- We need to determine the actual CLA text. This will likely require lawyers. To aid with this, http://contributoragreements.org/ exists to allow you to generate a CLA by simply answering some questions.
+- CLAs introduce a barrier to contributors whom may be reluctant to sign a legal document. For contributors that work for an entity/company, they often must get permission from their company to sign any CLAs
+- We need to enforce and maintain our CLAs. Thankfully, free and open-source services like https://cla-assistant.io/ exist to handle this.
+
+If a CLA is not adopted upfront, it is problematic to introduce a CLA at a later date.
+
+### Trademark
+
+Once we determine trademark ownership, we should link to a trademark usage document.


### PR DESCRIPTION
This work is a joint collaboration between @jmandel, @isaacvetter, @brynrhodes, @mattberther, and myself. Thanks to many others who reviewed a draft of this proposed governance model and provided feedback.

As CDS Hooks matures as a community and standard, we feel it is important to formalize our governance process and establish a code of conduct. This will ensure that we all work in the same manner and have clear expectations for how we work.

Feedback and comments from everyone is welcome.

I will have an update for this pull request where both the governance and code of conduct are referenced in the homepage.