### PR TITLE
Update the Ruby versions that Travis-CI builds use

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ sudo: false
 language: ruby
 
 rvm:
-  - 2.0.0
-  - 2.1.0
+  - 2.3
+  - 2.4
 
 cache: bundler
 script: bundle exec middleman build


### PR DESCRIPTION
Update the Ruby versions that Travis-CI builds use to avoid errors during builds for missing Rubies. Additionally, by specifying just the major and minor version and not the revision (eg, 2.3 instead of 2.3.0), this will allow Travis to use the latest revision/patch during builds.

This should fix the [recent Travis-CI build failures](https://travis-ci.org/cds-hooks/docs/jobs/257608496):

```
5.72s$ rvm use 2.1.0 --install --binary --fuzzy
ruby-2.1.0 is not installed - installing.
Searching for binary rubies, this might take some time.
Requested binary installation but no rubies are available to download, consider skipping --binary flag.
Gemset '' does not exist, 'rvm ruby-2.1.0 do rvm gemset create ' first, or append '--create'.
The command "rvm use 2.1.0 --install --binary --fuzzy" failed and exited with 2 during .
Your build has been stopped.
```