### PR TITLE
Add support for versioning the specification

### DIFF
--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -1,5 +1,8 @@
 # CDS Services
 
+!!! info "1.0 Draft"
+    This is the draft of the 1.0 release of the CDS Hooks specification. We are currently working towards a 1.0 release and would love your feedback and proposed changes. Look at our <a href="http://github.com/cds-hooks/docs/issues">current issue list</a> and get involved!
+
 ## Discovery
 
 ```shell

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,7 +12,8 @@ extra:
 
 pages:
 - Overview: 'index.md'
-- Specification: 'specification.md'
+- Specification:
+    - '1.0': 'specification/1.0.md'
 - Hooks: 'hooks.md'
 - Examples: 'examples.md'
 - Community: 'community.md'


### PR DESCRIPTION
This PR adds support for versioning the CDS Hooks specification. Today, the specification lives at `/specification`. With this change, it is now at `/specification/1.0`.

Future versioning can live at similar URLs. Eg:
- `/specification/1.1`
- `/specification/2.0`

This fixes #100