### PR TITLE
Remove decisions for the 1.0 release

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -36,22 +36,8 @@ materials (*app link card*). A user sees these cards — one or more of each typ
 
 * *suggestion card*: provides a specific suggestion for which the EHR renders a button that the user can click to accept. Clicking automatically populates the suggested change into the EHR's UI.
 
-* *app link card*: provides a link to an app (often a SMART app) where the user can supply details, step through a flowchart, or do anything else required to help reach an informed decision. When the user has finished, flow returns to the EHR. At that point, the **EHR re-triggers the initial CDS hook**. The re-triggering may result in different cards, and may also include **decisions** (see below).
-
-## CDS Decisions
-
-In addition to cards, a CDS service may also return **decisions** — but only
-after a user has interacted with the service via an *app link card*.
-Returning a decision allows the the CDS service to communicate the user's choices  to the EHR without displaying an additional card.  For
-example, a user might launch a hypertension management app, and upon
-returning to the EHR's prescription page she expects her new blood pressure
-prescription to "just be there". By returning a decision *instead of a card*,
-the CDS service achieves this expected behavior. (*Note:* To return a
-decision after a user interaction, the CDS service must maintain state
-associated with the request's `hookInstance`;
-when the EHR invokes the hook for a second time with the same
-`hookInstance`, the service can respond with decisions on as well as cards.)
+* *app link card*: provides a link to an app (often a SMART app) where the user can supply details, step through a flowchart, or do anything else required to help reach an informed decision.
 
 ## Try it!
 
-You can try CDS Hooks in our test harness at **[http://sandbox.cds-hooks.org](http://sandbox.cds-hooks.org)**
+You can try CDS Hooks in our Sandbox at **[http://sandbox.cds-hooks.org](http://sandbox.cds-hooks.org)**

--- a/docs/specification/1.0-api.yaml
+++ b/docs/specification/1.0-api.yaml
@@ -44,7 +44,7 @@ paths:
             $ref: '#/definitions/CDS Request'
       responses:
         200:
-          description: Success (includes CDS Cards and Decisions)
+          description: Success (includes CDS Cards)
           schema:
             $ref: '#/definitions/CDS Response'
 
@@ -108,8 +108,6 @@ definitions:
         format: url
       oauth:
         type: object
-      redirect:
-        type: string
       user:
         type: string
       patient:
@@ -130,8 +128,6 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/Card'
-      decisions:
-        type: object
 
   Card:
     type: object

--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -127,24 +127,9 @@ Field | Description
 
 #### hookInstance
 
-While working in the EHR, a user can perform
-multiple activities in series or in parallel. For example, a clinician might prescribe
-two drugs in a row; each prescription activity would be assigned a
-unique `hookInstance`. The [[activity catalog|Activity]]
-provides a description of what events should initiate and terminate
-a given hook. This allows an external
-service to associate requests with activity state, which is necessary to
-support the following app-centric decision sequence, where
-the steps are tied together by a common `hookInstance`:
+While working in the EHR, a user can perform multiple actions in series or in parallel. For example, a clinician might prescribe two drugs in a row; each prescription action would be assigned a unique `hookInstance`. This allows a CDS Service to uniquely identify each hook invocation.
 
-  0. EHR invokes CDS hook
-  1. CDS service returns *app link card*
-  2. User clicks app link and interacts with app
-  3. Flow returns to EHR, which re-invokes CDS hook
-  4. CDS service returns *decision* with user's choice
-
-Note: the `hookInstance` is globally unique and should contain enough entropy
-to be un-guessable.
+Note: the `hookInstance` is globally unique and should contain enough entropy to be un-guessable.
 
 #### redirect
 
@@ -217,9 +202,6 @@ You can see the <a href="http://editor.swagger.io/?url=https://raw.githubusercon
 Field | Description
 ----- | -----------
 `cards` |*array*. An array of **Cards**. Cards can provide a combination of information (for reading), suggested actions (to be applied if a user selects them), and links (to launch an app if the user selects them). The EHR decides how to display cards, but we recommend displaying suggestions using buttons, and links using underlined text.
-<nobr>`decisions`</nobr> |*array*. An array of **Decisions**. A decision should only be generated after interacting with the user through an app link. Decisions are designed to convey any choices the user made in an app session.
-
-represents a user's choice made while interacting with the CDS Provider's external app. The first call to a service should never include any `decisions`, since no user interaction has occurred yet.
 
 Each **Card** is described by the following attributes.
 
@@ -263,14 +245,6 @@ Field | Description
 <nobr>`label`</nobr>| *string*. human-readable label to display for this link (e.g. the EHR might render this as the underlined text of a clickable link).
 `url` | *URL*. URL to load (via `GET`, in a browser context) when a user clicks on this link. Note that this may be a "deep link" with context embedded in path segments, query parameters, or a hash. In general this URL should embed enough context for the app to determine the `hookInstance`, and `redirect` url upon downstream launch, because the EHR will simply use this url as-is, without appending any parameters at launch time.
 `type` | *string*. The type of the given URL. There are two possible values for this field. A type of `absolute` indicates that the URL is absolute and should be treated as-is. A type of `smart` indicates that the URL is a SMART app launch URL and the EHR should ensure the SMART app launch URL is populated with the appropriate SMART launch parameters.
-
-
-Each **Decision** is described by the following attributes.
-
-Field | Description
------ | -----------
-`create` |*array* of *strings*. id(s) of new resource(s) that the EHR should create within the current activity (e.g. for `medication-prescribe`, this would be the updated prescription that a user had authored in an app session).
-<nobr>`delete`</nobr> |*array* of *strings*. id(s) of any resources to remove from the current activity (e.g. for the `order-review` activity, this would provide a way to remove orders from the pending list). In activities like `medication-prescribe` where only one "content" resource is ever relevant, this field may be omitted.
 
 ### No Decision Support
 

--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -84,7 +84,6 @@ curl
    "hookInstance" : "d1577c69-dfbe-44ad-ba6d-3e05e953b2ea",
    "fhirServer" : "http://hooks.smarthealthit.org:9080",
    "hook" : "patient-view",
-   "redirect" : "http://hooks2.smarthealthit.org/service-done.html",
    "user" : "Practitioner/example",
    "context" : [],
    "patient" : "1288992",
@@ -118,7 +117,6 @@ Field | Description
 <nobr>`hookInstance`</nobr> |*string*.  A UUID for this particular hook call (see more information below)
 `fhirServer` |*URL*.  The base URL EHR's [FHIR](https://www.hl7.org/fhir/) server. The scheme should be `https`
 `fhirAuthorization` | *object*. The OAuth 2 authorization providing access to the EHR's FHIR server. See the [FHIR Resource Access](#fhir-resource-access) heading of the security section for more information.
-`redirect` |*URL*.  The URL an app link card should redirect to (see more information below)
 `user` |*string*.  The FHIR resource type + id representing the current user.<br />The type is one of: [Practitioner](https://www.hl7.org/fhir/practitioner.html), [Patient](https://www.hl7.org/fhir/patient.html), or [RelatedPerson](https://www.hl7.org/fhir/relatedperson.html).<br />For example, `Practitioner/123`
 `patient` |*string*.  The FHIR `Patient.id` of the current patient in context
 `encounter` |*string*.  The FHIR `Encounter.id` of the current encounter in context
@@ -130,16 +128,6 @@ Field | Description
 While working in the EHR, a user can perform multiple actions in series or in parallel. For example, a clinician might prescribe two drugs in a row; each prescription action would be assigned a unique `hookInstance`. This allows a CDS Service to uniquely identify each hook invocation.
 
 Note: the `hookInstance` is globally unique and should contain enough entropy to be un-guessable.
-
-#### redirect
-
-This field is only used by services that will return an *app
-link card*: when a user clicks the card's link to launch an app, it becomes
-the app's job to send the user to *this `redirect` URL* upon completion of
-user interaction. (*Design note*: this field is supplied up-front, as part of
-the initial request, to avoid requiring the EHR to append any content to app
-launch links. This helps support an important "degenerate" use case for app
-link cards: pointing to static content. See below for details.)
 
 #### prefetch
 
@@ -243,7 +231,7 @@ Each **Link** is described by the following attributes.
 Field | Description
 ----- | -----------
 <nobr>`label`</nobr>| *string*. human-readable label to display for this link (e.g. the EHR might render this as the underlined text of a clickable link).
-`url` | *URL*. URL to load (via `GET`, in a browser context) when a user clicks on this link. Note that this may be a "deep link" with context embedded in path segments, query parameters, or a hash. In general this URL should embed enough context for the app to determine the `hookInstance`, and `redirect` url upon downstream launch, because the EHR will simply use this url as-is, without appending any parameters at launch time.
+`url` | *URL*. URL to load (via `GET`, in a browser context) when a user clicks on this link. Note that this may be a "deep link" with context embedded in path segments, query parameters, or a hash.
 `type` | *string*. The type of the given URL. There are two possible values for this field. A type of `absolute` indicates that the URL is absolute and should be treated as-is. A type of `smart` indicates that the URL is a SMART app launch URL and the EHR should ensure the SMART app launch URL is populated with the appropriate SMART launch parameters.
 
 ### No Decision Support

--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -169,6 +169,11 @@ You can see the <a href="http://editor.swagger.io/?url=https://raw.githubusercon
           "type": "absolute"
         },
         {
+          "label": "Github",
+          "url": "https://github.com",
+          "type": "absolute"
+        },
+        {
           "label": "SMART Example App",
           "url": "https://smart.example.com/launch",
           "type": "smart"

--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -165,11 +165,6 @@ You can see the <a href="http://editor.swagger.io/?url=https://raw.githubusercon
           "type": "absolute"
         },
         {
-          "label": "Github",
-          "url": "https://github.com",
-          "type": "absolute"
-        },
-        {
           "label": "SMART Example App",
           "url": "https://smart.example.com/launch",
           "type": "smart"


### PR DESCRIPTION
Remove decisions and the `redirect` parameter in preparation for a 1.0 release.

Fixes #99.