### PR TITLE
Service Specification

### DIFF
--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -58,18 +58,18 @@ The discovery endpoint is always available at `{baseUrl}/cds-services`. For exam
 The response to the discovery endpoint is an object containing a list of CDS Services.
 
 Field | Description
------ | -----------
+----- | ---------
 `services` | *array*. An array of **CDS Services**
 
 Each CDS Service is described by the following attributes.
 
-Field | Description
------ | -----------
-`hook`| *string* or *url*. The hook this service should be invoked on. See [Hook Catalog](#hook-catalog)
-`title`| *string*.  The human-friendly name of this service
-<nobr>`description`</nobr>| *string*. The description of this service
-`id` | *string*. The {id} portion of the URL to this service which is available at<br />`{baseUrl}/cds-services/{id}`
-`prefetch` | *object*. An object containing key/value pairs of FHIR queries to data that this service would like the EHR prefetch and provide on<br />each service call. The key is a *string* that describes the type<br />of data being requested and the value is a *string* representing<br />the FHIR query.<br />(todo: link to prefetching documentation)
+Field | Priority | Description
+----- | ----- | ---------
+`hook`| REQUIRED | *string* or *url*. The hook this service should be invoked on. See [Hook Catalog](#hook-catalog)
+`title`| RECOMMENDED | *string*.  The human-friendly name of this service
+<nobr>`description`</nobr>| REQUIRED | *string*. The description of this service
+`id` | REQUIRED | *string*. The {id} portion of the URL to this service which is available at<br />`{baseUrl}/cds-services/{id}`
+`prefetch` | RECOMMENDED | *object*. An object containing key/value pairs of FHIR queries to data that this service would like the EHR prefetch and provide on<br />each service call. The key is a *string* that describes the type<br />of data being requested and the value is a *string* representing<br />the FHIR query.<br />(todo: link to prefetching documentation)
 
 ### HTTP Status Codes
 


### PR DESCRIPTION
I've tightened up the table showing the fields in a service description such that each field has an associated "priority" of REQUIRED, RECOMMENDED, or OPTIONAL (not used in this example).  This change illustrates my recommendation that the 1.0 spec needs to be specified more explicitly.  In addition, it carries out my recommendation to make the Prefetch field RECOMMENDED rather than required, so that each provider can decide whether to prefetch or allow the CDS service to fetch its own data as needed.