### PR TITLE
Document CDS Services should abide by accessing only the minimum necessary data neeeded

### DIFF
--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -71,7 +71,7 @@ Field | Priority | Description
 `title`| OPTIONAL | *string*.  The human-friendly name of this service
 <nobr>`description`</nobr>| REQUIRED | *string*. The description of this service
 `id` | OPTIONAL | *string*. The {id} portion of the URL to this service which is available at<br />`{baseUrl}/cds-services/{id}`
-`prefetch` | REQUIRED | *object*. An object containing key/value pairs of FHIR queries to data that this service requires in order to fulfill <br />each service call. The key is a *string* that describes the type<br />of data being requested and the value is a *string* representing<br />the FHIR query.<br />(todo: link to prefetching documentation)
+`prefetch` | PREFERRED | *object*. An object containing key/value pairs of FHIR queries to data that this service requires in order to fulfill <br />each service call. The key is a *string* that describes the type<br />of data being requested and the value is a *string* representing<br />the FHIR query.<br />(todo: link to prefetching documentation)
 
 ### HTTP Status Codes
 

--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -45,7 +45,9 @@ curl "https://example.com/cds-services"
 }
 ```
 
-Developers of CDS Services must provide a well-known endpoint allowing the EHR to discover all available CDS Services, including information such as the purpose of the CDS Service, when it should be invoked, and any data that is requested to be prefetched.
+Developers of CDS Services must provide a well-known endpoint allowing the EHR to discover all available CDS Services, including information such as the purpose of the CDS Service, when it should be invoked, and any data that are requested to be prefetched.
+
+Note that CDS Hooks service providers offer clinical services, and as such will be responsible (as HIPAA covered entities or business associates) for enforcing the "minimum necessary" rule.  Each CDS service MUST assure that the data elements requested to be "prefetched" are the minimum necessary to fulfill the CDS service request.  
 
 ### HTTP Request
 
@@ -63,13 +65,13 @@ Field | Description
 
 Each CDS Service is described by the following attributes.
 
-Field | Description
------ | -----------
-`hook`| *string* or *url*. The hook this service should be invoked on. See [Hook Catalog](#hook-catalog)
-`title`| *string*.  The human-friendly name of this service
-<nobr>`description`</nobr>| *string*. The description of this service
-`id` | *string*. The {id} portion of the URL to this service which is available at<br />`{baseUrl}/cds-services/{id}`
-`prefetch` | *object*. An object containing key/value pairs of FHIR queries to data that this service would like the EHR prefetch and provide on<br />each service call. The key is a *string* that describes the type<br />of data being requested and the value is a *string* representing<br />the FHIR query.<br />(todo: link to prefetching documentation)
+Field | Priority | Description
+----- | ----- | ---------
+`hook`| REQUIRED | *string* or *url*. The hook this service should be invoked on. See [Hook Catalog](#hook-catalog)
+`title`| OPTIONAL | *string*.  The human-friendly name of this service
+<nobr>`description`</nobr>| REQUIRED | *string*. The description of this service
+`id` | OPTIONAL | *string*. The {id} portion of the URL to this service which is available at<br />`{baseUrl}/cds-services/{id}`
+`prefetch` | REQUIRED | *object*. An object containing key/value pairs of FHIR queries to data that this service requires in order to fulfill <br />each service call. The key is a *string* that describes the type<br />of data being requested and the value is a *string* representing<br />the FHIR query.<br />(todo: link to prefetching documentation)
 
 ### HTTP Status Codes
 


### PR DESCRIPTION
Added clarification that the data elements a CDS service requests to be prefetched needs to be the "minimum necessary."  
Added priorities to CDS description table.  Responsive to risk #R16 from CDS service perspective.

Note that the table includes the statement "(todo: link to prefetching documentation)."  If this documentation does not exist, suggest deleting this statement.  Else add the link.