### PR TITLE
Improve FHIR Resource Access documentation

### DIFF
--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -445,46 +445,65 @@ At this time, CDS Hooks does not prescribe how the EHR shares its public key or 
 
 ### FHIR Resource Access
 
-The CDS Service is able to use the FHIR server of the EHR to obtain any additional data it needs in order to perform its decision support. This is similar to SMART on FHIR where the SMART app can obtain additional data via the provided FHIR server.
+The CDS Service is able to use the EHR's FHIR server to obtain any FHIR resources it requires beyond those provided by the EHR as prefetched data. This is similar to the approach used by SMART on FHIR wherein the SMART app requests and ultimately obtains an access token from the EHR's Authorization server using the SMART launch workflow, as described in [Smart App Authorization Guide](http://docs.smarthealthit.org/authorization/).  This process utilizes the authorization code grant model as defined by the [OAuth 2.0 Authorization Framework (RFC6749)](https://tools.ietf.org/html/rfc6749).
 
-Like SMART on FHIR, CDS Hooks requires that access to the FHIR server be controlled by an Authorization server utilizing the OAuth 2 framework. Thus, the CDS Service is able to consume the given FHIR server via an access (bearer) token just like a SMART app. While CDS Hooks shares the underlying technical framework and standards as SMART on FHIR, there are very important differences between SMART and CDS Hooks.
+Like SMART on FHIR, CDS Hooks requires that requested accesses to the FHIR server be mediated and authorized by an Authorization server in accordance with the OAuth 2.0 Authorization Framework. Thus, the CDS Service is able to retrieve FHIR resources by presenting an access (bearer) token issued for this purpose.  While CDS Hooks shares the underlying technical framework and standards as SMART on FHIR, the CDS Hooks workflow incorporates a more efficient means of enabling the CDS service to obtain the access token.  
+
+With CDS Hooks, if the EHR wants to provide the CDS Service direct access to FHIR resources, the EHR prefetches an access token and passes the token on to the CDS Service in the service call. This performance enhancement enables CDS Hooks to require use of the OAuth 2.0 authorization code grant model, while avoiding several HTTPS calls and redirects.  As a CDS Service may be invoked multiple times within a single workflow, requiring the CDS service to request authorization for every hook invocation would likely result in a poorly performing CDS Service due to the authorization overhead.  This approach circumvents the need for the CDS Service to request access from the authorization server directly, while at the same time assuring that the authorization server is aware that the access token will ultimately be used by the CDS Service, rather than the EHR that issued the request.
 
 #### Obtaining an Access Token
 
-In SMART on FHIR, the SMART app requests and ultimately obtains an access token from the Authorization server using the SMART launch workflow. This process utilizes the authorization code grant model as defined by the OAuth 2.0 Authorization Framework in [rfc6749](https://tools.ietf.org/html/rfc6749).
+An EHR MAY enable a CDS Service to retrieve FHIR resources directly from a FHIR server through the use of a bearer token issued for use by the CDS Service, and passed to the CDS Service in the service request.  If the EHR chooses to obtain a bearer token for CDS Service use, the authorization MUST be accomplished in accordance with the OAuth 2.0 authorization code grant model, and the authorization request MUST identify the CDS Service by name as the intended user.  This identifier MUST BE the name by which the CDS Service is pre-registered with the EHR Authorization Server.      
 
-With CDS Hooks, the EHR provides the access token directly in the request to the CDS Service. Thus, the CDS Service does not need to request the token from the authorization server as a SMART app would. This is done purely for performance reasons as the authorization code grant model in OAuth 2 involves several HTTPS calls and redirects. In contrast to a SMART app, a CDS Service may be invoked many times during a workflow. Going through the authorization code grant model on every hook invocation would likely result in a poorly performing CDS Service due to the authorization overhead.
+The EHR authorization request includes the following parameters:
+ 
+ Field | Priority | Description
+ ----- | ----- | --------
+ response_type | REQUIRED | Fixed value:  code
+ client_id | REQUIRED | EHR requesting authorization
+ redirect_URI | REQUIRED | EHR's redirect URI
+ subject | REQUIRED | The authorized accessor (CDS Service) for which the access token is being requested 
+ scope | REQUIRED | The access being requested 
+ state | REQUIRED | Opaque value used by the EHR to maintain state between the request and callback 
+ aud | REQUIRED | The FHIR server (fhirServer) from which resources will be retrieved
+ 
+The `scope` value SHOULD contain the minimum necessary scopes the CDS Service requires to compute its logic.  As the CDS Service executes on behalf of a user, the data to which the CDS Service is given access SHOULD BE limited to the same restrictions and authorizations afforded the current user. As such, the access token SHALL BE scoped to:
+
+- The CDS Service being invoked
+- The current user
+
+If the authorization request is granted, the authorization server returns an authorization code that the EHR exchanges for a bearer access token.  The access token is a string of characters as defined in [RFC6749](https://tools.ietf.org/html/rfc6749) and [RFC6750](https://tools.ietf.org/html/rfc6750).  The token is essentially a private message that the authorization server passes to the FHIR Server, telling the FHIR server that the “message bearer” has been authorized to access the specified resources.  Defining the format and content of the access token is left up to the organization that issues the access token and holds the requested resource.
+
+The authorization server’s response MUST include the HTTP “Cache-Control” response header field with a value of “no-store." The expiry time for which the token remains value SHOULD BE set as short as possible to provide the requested decision support.
 
 ```json
 {
   "fhirAuthorization" : {
     "access_token" : "some-opaque-fhir-access-token",
-    "token_type" : "Bearer",
+    "token_type" : "bearer",
     "expires_in" : 300,
     "scope" : "patient/Patient.read patient/Observation.read"
+    "state" : "wobierabieostoe380",
+    "subject" : "cds-service4",
+    "aud" : "http://fhirServer.ehr.com
   }
 }
 ```
 
-#### Access Token
+#### Passing the Access Token to the CDS Service
 
-The access token is specified in the CDS Service request via the `fhirAuthorization` request parameter. This parameter is an object that contains both the access token as well as other related information.
+The access token is specified in the CDS Service request via the OPTIONAL `fhirAuthorization` request parameter. This parameter is an object that contains both the access token as well as other related information.  If the EHR chooses not to pass along an access token, the `fhirAuthorization` parameter is omitted.  
 
-Field | Description
------ | -----------
-`access_token` |*string*. This is the OAuth 2 access token that provides access to the FHIR server.
-`token_type`   |*string*. Fixed value: `Bearer`
-`expires_in`   |*integer*. The lifetime in seconds of the access token.
-`scope`        |*string*. The scopes the access token grants the CDS Service.
+Field | Priority | Description
+----- | ----- | -----------
+`access_token` | REQUIRED | *string*. This is the OAuth 2 access token that provides access to the FHIR server.
+`token_type`   | REQUIRED | *string*. Fixed value: `Bearer`
+`expires_in`   | REQUIRED | *integer*. The lifetime in seconds of the access token.
+`scope`        | REQUIRED | *string*. The scopes the access token grants the CDS Service.
+`subject` | REQUIRED | *string*.  The CDS Service as registered with the EHR.
+`aud` | REQUIRED | *URI*
 
-It is recommended that the `expires_in` value be very short lived as the access token must be treated as a transient value by the CDS Service.
-
-It is recommended that the `scope` value contain just the scopes that the CDS Service needs for its logic and no more.
-
-As the CDS Service is executing on behalf of a user, it is important that the data the CDS Service has access to is under the same restrictions/authorization as the current user. As such, the access token shall be scoped to:
-
-- The CDS Service being invoked
-- The current user
+The `expires_in` value is established by the authorization server and SHOULD BE very short lived, as the access token must be treated as a transient value by the CDS Service.
 
 ### Cross-Origin Resource Sharing
 

--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -481,11 +481,10 @@ The authorization server’s response MUST indicate that the access token MAY NO
 {
   "fhirAuthorization" : {
     "access_token" : "some-opaque-fhir-access-token",
-    "token_type" : "bearer",
+    "token_type" : "Bearer",
     "expires_in" : 300,
     "scope" : "patient/Patient.read patient/Observation.read",
     "subject" : "cds-service4",
-    "aud" : "http://fhirServer.ehr.com
   }
 }
 ```
@@ -497,10 +496,10 @@ The access token is specified in the CDS Service request via the OPTIONAL `fhirA
 Field | Priority | Description
 ----- | ----- | -----------
 `access_token` | REQUIRED | *string*. This is the OAuth 2 access token that provides access to the FHIR server.
-`token_type`   | REQUIRED | *string*. Fixed value: `Bearer`
+`token_type`   | REQUIRED | *string*. Fixed value: `Bearer`.
 `expires_in`   | REQUIRED | *integer*. The lifetime in seconds of the access token.
 `scope`        | REQUIRED | *string*. The scopes the access token grants the CDS Service.
-`subject` | REQUIRED | *string*.  The CDS Service as registered with the EHR.
+`subject` | REQUIRED | *string*.  The OAuth 2.0 client identifier of the CDS Service, as registered with the EHR's authorization server.
 
 The `expires_in` value is established by the authorization server and SHOULD BE very short lived, as the access token must be treated as a transient value by the CDS Service.
 

--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -455,16 +455,14 @@ With CDS Hooks, if the EHR wants to provide the CDS Service direct access to FHI
 
 An EHR MAY enable a CDS Service to retrieve FHIR resources directly from a FHIR server through the use of a bearer token issued for use by the CDS Service, and passed to the CDS Service in the service request.  If the EHR chooses to obtain a bearer token for CDS Service use, the authorization MUST be accomplished in accordance with the OAuth 2.0 authorization code grant model, and the authorization request MUST identify the CDS Service by name as the intended user.  This identifier MUST BE the name by which the CDS Service is pre-registered with the EHR Authorization Server.      
 
-The EHR authorization request includes the following parameters:
+The transaction the EHR uses to request authorization MUST include the following parameters:
  
- Field | Priority | Description
- ----- | ----- | --------
- response_type | REQUIRED | Fixed value:  code
- client_id | REQUIRED | EHR requesting authorization
- redirect_URI | REQUIRED | EHR's redirect URI
- subject | REQUIRED | The authorized accessor (CDS Service) for which the access token is being requested 
+ Field | Description
+ ----- | --------
+ response_type | Fixed value:  code
+ client_id | EHR requesting authorization
+ subject | client_id of authorized accessor (CDS Service) for which the access token is being requested 
  scope | REQUIRED | The access being requested 
- state | REQUIRED | Opaque value used by the EHR to maintain state between the request and callback 
  aud | REQUIRED | The FHIR server (fhirServer) from which resources will be retrieved
  
 The `scope` value SHOULD contain the minimum necessary scopes the CDS Service requires to compute its logic.  As the CDS Service executes on behalf of a user, the data to which the CDS Service is given access SHOULD BE limited to the same restrictions and authorizations afforded the current user. As such, the access token SHALL BE scoped to:
@@ -474,7 +472,7 @@ The `scope` value SHOULD contain the minimum necessary scopes the CDS Service re
 
 If the authorization request is granted, the authorization server returns an authorization code that the EHR exchanges for a bearer access token.  The access token is a string of characters as defined in [RFC6749](https://tools.ietf.org/html/rfc6749) and [RFC6750](https://tools.ietf.org/html/rfc6750).  The token is essentially a private message that the authorization server passes to the FHIR Server, telling the FHIR server that the “message bearer” has been authorized to access the specified resources.  Defining the format and content of the access token is left up to the organization that issues the access token and holds the requested resource.
 
-The authorization server’s response MUST include the HTTP “Cache-Control” response header field with a value of “no-store." The expiry time for which the token remains value SHOULD BE set as short as possible to provide the requested decision support.
+The authorization server’s response MUST indicate that the access token MAY NOT be cached or otherwise persisted in data storage.  The expiry time for which the token remains value SHOULD BE set as short as possible to provide the requested decision support.
 
 ```json
 {
@@ -482,8 +480,7 @@ The authorization server’s response MUST include the HTTP “Cache-Control” 
     "access_token" : "some-opaque-fhir-access-token",
     "token_type" : "bearer",
     "expires_in" : 300,
-    "scope" : "patient/Patient.read patient/Observation.read"
-    "state" : "wobierabieostoe380",
+    "scope" : "patient/Patient.read patient/Observation.read",
     "subject" : "cds-service4",
     "aud" : "http://fhirServer.ehr.com
   }
@@ -501,7 +498,6 @@ Field | Priority | Description
 `expires_in`   | REQUIRED | *integer*. The lifetime in seconds of the access token.
 `scope`        | REQUIRED | *string*. The scopes the access token grants the CDS Service.
 `subject` | REQUIRED | *string*.  The CDS Service as registered with the EHR.
-`aud` | REQUIRED | *URI*
 
 The `expires_in` value is established by the authorization server and SHOULD BE very short lived, as the access token must be treated as a transient value by the CDS Service.
 

--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -470,7 +470,7 @@ The `scope` value SHOULD contain the minimum necessary scopes the CDS Service re
 - The CDS Service being invoked
 - The current user
 
-If the authorization request is granted, the authorization server returns an authorization code that the EHR exchanges for a bearer access token.  The access token is a string of characters as defined in [RFC6749](https://tools.ietf.org/html/rfc6749) and [RFC6750](https://tools.ietf.org/html/rfc6750).  The token is essentially a private message that the authorization server passes to the FHIR Server, telling the FHIR server that the “message bearer” has been authorized to access the specified resources.  Defining the format and content of the access token is left up to the organization that issues the access token and holds the requested resource.
+If the authorization request is granted, the authorization server returns an authorization code that the EHR exchanges for a bearer access token.  The access token is a string of characters as defined in [RFC6749](https://tools.ietf.org/html/rfc6749) and [RFC6750](https://tools.ietf.org/html/rfc6750) and should have high entropy.  The token is essentially a private message that the authorization server passes to the FHIR Server, telling the FHIR server that the “message bearer” has been authorized to access the specified resources.  Defining the format and content of the access token is left up to the organization that issues the access token and holds the requested resource.
 
 The authorization server’s response MUST indicate that the access token MAY NOT be cached or otherwise persisted in data storage.  The expiry time for which the token remains value SHOULD BE set as short as possible to provide the requested decision support.
 


### PR DESCRIPTION
Incorporates all of the concepts we have discussed w.r.t. enabling an EHR to obtain a bearer token on behalf of a CDS service, and passing it on to that service in the service request.  I moved all of the pre-existing discussion re SMART into to introductory section so that the specification sections could be purely specification.  

I discovered that RFC7521 defines the "subject" parameter as "When using assertions as an authorization grant, the Subject identifies an authorized accessor for which the access token is being requested (typically, the resource owner or an authorized delegate)."  This seems to fit our purposes nicely, so I have used that as the identifier of the CDS Service that will be using the token.  