### PR TITLE
Minor edit to fhirAuthorization field documentation and example

### DIFF
--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -135,7 +135,7 @@ Field | Description
 `hook` |*string* or *URL*. The hook that triggered this CDS Service call<br />(todo: link to hook documentation)
 <nobr>`hookInstance`</nobr> |*string*.  A UUID for this particular hook call (see more information below)
 `fhirServer` |*URL*.  The base URL EHR's [FHIR](https://www.hl7.org/fhir/) server. The scheme should be `https`
-`fhirAuthorization` | *object*. The OAuth 2.0 bearer access token granting the CDS Service access to FHIR resources. See the [FHIR Resource Access](#fhir-resource-access) heading of the security section for more information.
+`fhirAuthorization` | *object*. A structure holding an OAuth 2.0 bearer access token granting the CDS Service access to FHIR resources, along with supplemental information relating to the token. See the [FHIR Resource Access](#fhir-resource-access) heading of the security section for more information.
 `user` |*string*.  The FHIR resource type + id representing the current user.<br />The type is one of: [Practitioner](https://www.hl7.org/fhir/practitioner.html), [Patient](https://www.hl7.org/fhir/patient.html), or [RelatedPerson](https://www.hl7.org/fhir/relatedperson.html).<br />For example, `Practitioner/123`
 `patient` |*string*.  The FHIR `Patient.id` of the current patient in context
 `encounter` |*string*.  The FHIR `Encounter.id` of the current encounter in context

--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -92,9 +92,11 @@ curl
    "hookInstance" : "d1577c69-dfbe-44ad-ba6d-3e05e953b2ea",
    "fhirServer" : "http://hooks.smarthealthit.org:9080",
    "hook" : "patient-view",
+   "fhirAuthorization" : "a93aa0b328a;nbeaoajwubelwodkca038",
    "user" : "Practitioner/example",
    "context" : [],
    "patient" : "1288992",
+   "encounter" : "home.id",
    "prefetch" : {
       "patientToGreet" : {
          "response" : {
@@ -124,7 +126,7 @@ Field | Description
 `hook` |*string* or *URL*. The hook that triggered this CDS Service call<br />(todo: link to hook documentation)
 <nobr>`hookInstance`</nobr> |*string*.  A UUID for this particular hook call (see more information below)
 `fhirServer` |*URL*.  The base URL EHR's [FHIR](https://www.hl7.org/fhir/) server. The scheme should be `https`
-`fhirAuthorization` | *object*. The OAuth 2 authorization providing access to the EHR's FHIR server. See the [FHIR Resource Access](#fhir-resource-access) heading of the security section for more information.
+`fhirAuthorization` | *object*. The OAuth 2.0 bearer access token granting the CDS Service access to FHIR resources. See the [FHIR Resource Access](#fhir-resource-access) heading of the security section for more information.
 `user` |*string*.  The FHIR resource type + id representing the current user.<br />The type is one of: [Practitioner](https://www.hl7.org/fhir/practitioner.html), [Patient](https://www.hl7.org/fhir/patient.html), or [RelatedPerson](https://www.hl7.org/fhir/relatedperson.html).<br />For example, `Practitioner/123`
 `patient` |*string*.  The FHIR `Patient.id` of the current patient in context
 `encounter` |*string*.  The FHIR `Encounter.id` of the current encounter in context

--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -92,11 +92,11 @@ curl
    "hookInstance" : "d1577c69-dfbe-44ad-ba6d-3e05e953b2ea",
    "fhirServer" : "http://hooks.smarthealthit.org:9080",
    "hook" : "patient-view",
-   "fhirAuthorization" : "a93aa0b328a;nbeaoajwubelwodkca038",
+   "fhirAuthorization" : "params.tokenUri",
    "user" : "Practitioner/example",
    "context" : [],
    "patient" : "1288992",
-   "encounter" : "home.id",
+   "encounter" : "89284",
    "prefetch" : {
       "patientToGreet" : {
          "response" : {


### PR DESCRIPTION
Modified example to align with parameters table by adding "fhirAuthorization" and "encounter" fields."  
Reworded description of "fhirAuthorization" parameter.
This change is responsive to Risk R7.