### PR TITLE
CDS Service Response Changes

### DIFF
--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -152,6 +152,84 @@ You can see the <a href="http://editor.swagger.io/?url=https://raw.githubusercon
 
 ## CDS Service Response
 
+### Card Array 
+
+Field | Priority | Description
+----- | ----- | --------
+`cards` | REQUIRED | *array*. An array of **Cards**. Cards can provide a combination of information (for reading), suggested actions (to be applied if a user selects them), and links (to launch an app if the user selects them). The EHR decides how to display cards, but we recommend displaying suggestions using buttons, and links using underlined text.
+
+If your CDS Service has no decision support for the user, your service should return a 200 HTTP response with an empty array of cards.
+
+> Response when no decision support is necessary for the user
+
+```json
+{
+  "cards": []
+}
+```
+
+### Card Attributes 
+
+Each **Card** is described by the following attributes.
+
+Field | Description
+----- | -----------
+`summary` | *string*. one-sentence, <140-character summary message for display to the user inside of this card.
+`detail` | *string*.  optional detailed information to display, represented in [(GitHub Flavored) Markdown](https://github.github.com/gfm/). (For non-urgent cards, the EHR may hide these details until the user clicks a link like "view more details...".) 
+`indicator` | *string*.  urgency/importance of what this card conveys. Allowed values, in order of increasing urgency, are: `info`, `warning`, `hard-stop`. The EHR can use this field to help make UI display decisions such as sort order or coloring. The value `hard-stop` indicates that the workflow should not be allowed to proceed. 
+`source` | *object*. grouping structure for the **Source** of the information displayed on this card. The source should be the primary source of guidance for the decision support the card represents.
+<nobr>`suggestions`</nobr> | *array* of **Suggestions**, which allow a service to suggest a set of changes in the context of the current activity (e.g.  changing the dose of the medication currently being prescribed, for the `medication-prescribe` activity). The user must be allowed to choose at most one suggestion.
+`links` | *array* of **Links**, which allow a service to suggest a link to an app that the user might want to run for additional information or to help guide a decision.
+
+#### Source
+
+The **Source** is described by the following attributes.
+
+Field | Priority | Description
+----- | ----- | --------
+<nobr>`label`</nobr>| REQUIRED | *string*. A short, human-readable label to display for the source of the information displayed on this card. If a `url` is also specified, this may be the text for the hyperlink.
+`url` | OPTIONAL | *URL*. An optional absolute URL to load (via `GET`, in a browser context) when a user clicks on this link to learn more about the organization or data set that provided the information on this card. Note that this URL should not be used to supply a context-specific "drill-down" view of the information on this card. For that, use `link.url` instead.
+`icon` | OPTIONAL | *URL*. An optional absolute URL to an icon for the source of this card. The icon returned by this URL should be in PNG format, an image size of 100x100 pixels, and must not include any transparent regions.
+
+#### Suggestion
+
+Each **Suggestion** is described by the following attributes.
+
+Field | Priority | Description
+----- | ----- | --------
+`label` | REQUIRED | *string*. human-readable label to display for this suggestion (e.g. the EHR might render this as the text on a button tied to this suggestion).
+`uuid` | OPTIONAL | *string*. unique identifier for this suggestion. For details see [Suggestion Tracking Analytics](#analytics)
+`actions` | OPTIONAL | *array*. array of objects, each defining a suggested action. Within a suggestion, all actions are logically AND'd together, such that a user selecting a suggestion selects all of the actions within it.
+
+Whenever a user clicks a displayed label (e.g., button) from a "suggestion" card, the EHR uses the
+suggestion `uuid` to notify the CDS Service's analytics endpoint via a `POST`
+with an empty body:
+
+    `POST {baseUrl}/cds-services/{serviceId}/analytics/{uuid}`
+
+If a suggestion has no `uuid`, the EHR does not send a notification.
+
+Each **Action** is described by the following attributes.
+
+Field | Priority | Description
+----- | ----- | --------
+`type` |  REQUIRED | *string*. The type of action being performed. Allowed values are: `create`, `update`, `delete`. 
+`description` | REQUIRED | *string*. human-readable description of the suggested action. May be presented to the end-user. 
+`resource` | OPTIONAL | *object*. depending upon the `type` attribute, a new resource or the id of a resource. For a type of `create`, the `resource` attribute contains a new FHIR resource to apply within the current activity (e.g. for `medication-prescribe`, this holds the updated prescription as proposed by the suggestion).  For `delete`, this is the id of any resource to remove from the current activity (e.g. for the `order-review` activity, this would provide a way to remove an order from the pending list). In activities like `medication-prescribe` where only one "content" resource is ever relevant, this field may be omitted. For `update`, this holds the updated resource to modify from the current activity (e.g. for the `order-review` activity, this would provide a way to annotate an order from the pending list with an assessment). 
+
+#### Link
+
+Each **Link** is described by the following attributes.
+
+Field | Priority | Description
+----- | ----- | --------
+<nobr>`label`</nobr>| REQUIRED | *string*. human-readable label to display for this link (e.g. the EHR might render this as the underlined text of a clickable link).
+`url` | REQUIRED | *URL*. URL to load (via `GET`, in a browser context) when a user clicks on this link. Note that this may be a "deep link" with context embedded in path segments, query parameters, or a hash.
+`type` | REQUIRED | *string*. The type of the given URL. There are two possible values for this field. A type of `absolute` indicates that the URL is absolute and should be treated as-is. A type of `smart` indicates that the URL is a SMART app launch URL and the EHR should ensure the SMART app launch URL is populated with the appropriate SMART launch parameters.
+`appContext` | OPTIONAL | *string*.  An optional field that allows the CDS Service to pass context regarding the launch of this SMART app from the CDS card to the SMART app. The `appContext` field should only be valued if the link type is `smart` and is not valid for `absolute` links. The `appContext` field and value will be sent to the SMART app as part of the OAuth 2 access token response, alongside the other launch context when the SMART app is launched.
+
+### Example
+
 > Example response
 
 ```json
@@ -196,76 +274,6 @@ You can see the <a href="http://editor.swagger.io/?url=https://raw.githubusercon
 }
 ```
 
-Field | Description
------ | -----------
-`cards` |*array*. An array of **Cards**. Cards can provide a combination of information (for reading), suggested actions (to be applied if a user selects them), and links (to launch an app if the user selects them). The EHR decides how to display cards, but we recommend displaying suggestions using buttons, and links using underlined text.
-
-Each **Card** is described by the following attributes.
-
-Field | Description
------ | -----------
-`summary` | *string*. one-sentence, <140-character summary message for display to the user inside of this card.
-`detail` | *string*.  optional detailed information to display, represented in [(GitHub Flavored) Markdown](https://github.github.com/gfm/). (For non-urgent cards, the EHR may hide these details until the user clicks a link like "view more details...".) 
-`indicator` | *string*.  urgency/importance of what this card conveys. Allowed values, in order of increasing urgency, are: `info`, `warning`, `hard-stop`. The EHR can use this field to help make UI display decisions such as sort order or coloring. The value `hard-stop` indicates that the workflow should not be allowed to proceed. 
-`source` | *object*. grouping structure for the **Source** of the information displayed on this card. The source should be the primary source of guidance for the decision support the card represents.
-<nobr>`suggestions`</nobr> | *array* of **Suggestions**, which allow a service to suggest a set of changes in the context of the current activity (e.g.  changing the dose of the medication currently being prescribed, for the `medication-prescribe` activity). The user must be allowed to choose at most one suggestion.
-`links` | *array* of **Links**, which allow a service to suggest a link to an app that the user might want to run for additional information or to help guide a decision.
-
-The **Source** is described by the following attributes.
-
-Field | Description
------ | -----------
-<nobr>`label`</nobr>| *string*. A short, human-readable label to display for the source of the information displayed on this card. If a `url` is also specified, this may be the text for the hyperlink.
-`url` | *URL*. An optional absolute URL to load (via `GET`, in a browser context) when a user clicks on this link to learn more about the organization or data set that provided the information on this card. Note that this URL should not be used to supply a context-specific "drill-down" view of the information on this card. For that, use `link.url` instead.
-`icon` | *URL*. An optional absolute URL to an icon for the source of this card. The icon returned by this URL should be in PNG format, an image size of 100x100 pixels, and must not include any transparent regions.
-
-Each **Suggestion** is described by the following attributes.
-
-Field | Description
------ | -----------
-`label` |  *string*. human-readable label to display for this suggestion (e.g. the EHR might render this as the text on a button tied to this suggestion).
-`uuid` | *string*. unique identifier for this suggestion. For details see [Suggestion Tracking Analytics](#analytics)
-`actions` | *array*. array of objects, each defining a suggested action. Within a suggestion, all actions are logically AND'd together, such that a user selecting a suggestion selects all of the actions within it.
-
-Each **Action** is described by the following attributes.
-
-Field | Description
------ | -----------
-`type` |  *string*. The type of action being performed. Allowed values are: `create`, `update`, `delete`. 
-`description` | *string*. human-readable description of the suggested action. May be presented to the end-user. 
-`resource` | *object*. depending upon the `type` attribute, a new resource or the id of a resource. For a type of `create`, the `resource` attribute contains a new FHIR resource to apply within the current activity (e.g. for `medication-prescribe`, this holds the updated prescription as proposed by the suggestion).  For `delete`, this is the id of any resource to remove from the current activity (e.g. for the `order-review` activity, this would provide a way to remove an order from the pending list). In activities like `medication-prescribe` where only one "content" resource is ever relevant, this field may be omitted. For `update`, this holds the updated resource to modify from the current activity (e.g. for the `order-review` activity, this would provide a way to annotate an order from the pending list with an assessment). This field may be omitted.
-
-Each **Link** is described by the following attributes.
-
-Field | Description
------ | -----------
-<nobr>`label`</nobr>| *string*. human-readable label to display for this link (e.g. the EHR might render this as the underlined text of a clickable link).
-`url` | *URL*. URL to load (via `GET`, in a browser context) when a user clicks on this link. Note that this may be a "deep link" with context embedded in path segments, query parameters, or a hash.
-`type` | *string*. The type of the given URL. There are two possible values for this field. A type of `absolute` indicates that the URL is absolute and should be treated as-is. A type of `smart` indicates that the URL is a SMART app launch URL and the EHR should ensure the SMART app launch URL is populated with the appropriate SMART launch parameters.
-`appContext` |*string*.  An optional field that allows the CDS Service to pass context regarding the launch of this SMART app from the CDS card to the SMART app. The `appContext` field should only be valued if the link type is `smart` and is not valid for `absolute` links. The `appContext` field and value will be sent to the SMART app as part of the OAuth 2 access token response, alongside the other launch context when the SMART app is launched.
-
-
-### No Decision Support
-
-> Response when no decision support is necessary for the user
-
-```json
-{
-  "cards": []
-}
-```
-
-If your CDS Service has no decision support for the user, your service should return a 200 HTTP response with an empty array of cards.
-
-## Analytics
-
-Whenever a user clicks a button from a "suggestion" card, the EHR uses the
-suggestion `uuid` to notify the CDS Service's analytics endpoint via a `POST`
-with an empty body:
-
-    `POST {baseUrl}/cds-services/{serviceId}/analytics/{uuid}`
-
-If a suggestion has no `uuid`, the EHR does not send a notification.
 
 ## Prefetch
 

--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -198,8 +198,10 @@ Each **Suggestion** is described by the following attributes.
 Field | Priority | Description
 ----- | ----- | --------
 `label` | REQUIRED | *string*. human-readable label to display for this suggestion (e.g. the EHR might render this as the text on a button tied to this suggestion).
-`uuid` | OPTIONAL | *string*. unique identifier for this suggestion. For details see [Suggestion Tracking Analytics](#analytics)
+`uuid` | OPTIONAL | *string*. unique identifier for this suggestion. For details see [Suggestion Tracking Analytics](#suggestion-tracking-analytics)
 `actions` | OPTIONAL | *array*. array of objects, each defining a suggested action. Within a suggestion, all actions are logically AND'd together, such that a user selecting a suggestion selects all of the actions within it.
+
+##### Suggestion Tracking Analytics
 
 Whenever a user clicks a displayed label (e.g., button) from a "suggestion" card, the EHR uses the
 suggestion `uuid` to notify the CDS Service's analytics endpoint via a `POST`
@@ -208,6 +210,8 @@ with an empty body:
     `POST {baseUrl}/cds-services/{serviceId}/analytics/{uuid}`
 
 If a suggestion has no `uuid`, the EHR does not send a notification.
+
+##### Action
 
 Each **Action** is described by the following attributes.
 


### PR DESCRIPTION
This section was very hard to follow, especially w.r.t. what attributes were expansions of other attributes, etc.  The following changes were made:
1.  Moved the example to follow the field specifications (as we discussed).
2. Added "Priority" to all tables (except for the Card Attributes because Priorities were added by PR #131).  
3. Added sub-sections to show nesting of attributes.
4. Integrated "No Decision Support" content into "Card Array" section.
5. Integrated "Analytics" content into "Suggestion" section.

Question:  The Suggestion table references something called "Suggestion Tracking Analytics."  Is this a reference to the (moved) "Analytics" section, or to a separate resource?