### PR TITLE
Calling a CDS Service Mods

### DIFF
--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -97,6 +97,33 @@ Code | Description
 
 ## Calling a CDS Service
 
+### HTTP Request
+
+An EHR calls a CDS service by `POST`ing a JSON document to the service
+endpoint, which can be constructed from the CDS Service base URL and an
+individual service id as `{baseUrl}/cds-services/{service.id}`.  The CDS Hook
+call includes a JSON POST body with the following input fields:
+
+Field | Priority | Description
+----- | ----- | --------
+`hook` | REQUIRED | *string* or *URL*. The hook that triggered this CDS Service call<br />(todo: link to hook documentation)
+<nobr>`hookInstance`</nobr> | REQUIRED | *string*.  A UUID for this particular hook call (see more information below)
+`fhirServer` | OPTIONAL | *URL*.  The base URL EHR's [FHIR](https://www.hl7.org/fhir/) server. If fhirAuthorization is provided, this field is REQUIRED.  The scheme should be `https`
+`fhirAuthorization` | OPTIONAL | *object*. A structure holding an OAuth 2.0 bearer access token granting the CDS Service access to FHIR resources, along with supplemental information relating to the token. See the [FHIR Resource Access](#fhir-resource-access) section for more information.
+`user` | REQUIRED | *string*.  The FHIR resource type + id representing the current user.<br />The type is one of: [Practitioner](https://www.hl7.org/fhir/practitioner.html), [Patient](https://www.hl7.org/fhir/patient.html), or [RelatedPerson](https://www.hl7.org/fhir/relatedperson.html).<br />For example, `Practitioner/123`
+`patient` | REQUIRED | *string*.  The FHIR `Patient.id` of the current patient in context
+`encounter` | REQUIRED | *string*.  The FHIR `Encounter.id` of the current encounter in context
+`context` | REQUIRED | *object*.  Hook-specific contextual data that the CDS service will need.<br />For example, with the `medication-prescribe` hook this will include [MedicationOrder](https://www.hl7.org/fhir/medicationorder.html) being prescribed.
+`prefetch` | OPTIONAL | *object*.  The FHIR data that was prefetched by the EHR (see more information below)
+
+#### hookInstance
+
+While working in the EHR, a user can perform multiple actions in series or in parallel. For example, a clinician might prescribe two drugs in a row; each prescription action would be assigned a unique `hookInstance`. This allows a CDS Service to uniquely identify each hook invocation.
+
+Note: the `hookInstance` is globally unique and should contain enough entropy to be un-guessable.
+
+### Example
+
 ```
 curl
   -X POST \
@@ -138,30 +165,6 @@ curl
 }
 ```
 
-### HTTP Request
-
-An EHR calls a CDS service by `POST`ing a JSON document to the service
-endpoint, which can be constructed from the CDS Service base URL and an
-individual service id as `{baseUrl}/cds-services/{service.id}`.  The CDS Hook
-call includes a JSON POST body with the following input fields:
-
-Field | Description
------ | -----------
-`hook` |*string* or *URL*. The hook that triggered this CDS Service call<br />(todo: link to hook documentation)
-<nobr>`hookInstance`</nobr> |*string*.  A UUID for this particular hook call (see more information below)
-`fhirServer` |*URL*.  The base URL EHR's [FHIR](https://www.hl7.org/fhir/) server. The scheme should be `https`
-`fhirAuthorization` | *object*. A structure holding an OAuth 2.0 bearer access token granting the CDS Service access to FHIR resources, along with supplemental information relating to the token. See the [FHIR Resource Access](#fhir-resource-access) heading of the security section for more information.
-`user` |*string*.  The FHIR resource type + id representing the current user.<br />The type is one of: [Practitioner](https://www.hl7.org/fhir/practitioner.html), [Patient](https://www.hl7.org/fhir/patient.html), or [RelatedPerson](https://www.hl7.org/fhir/relatedperson.html).<br />For example, `Practitioner/123`
-`patient` |*string*.  The FHIR `Patient.id` of the current patient in context
-`encounter` |*string*.  The FHIR `Encounter.id` of the current encounter in context
-`context` |*object*.  Hook-specific contextual data that the CDS service will need.<br />For example, with the `medication-prescribe` hook this will include [MedicationOrder](https://www.hl7.org/fhir/medicationorder.html) being prescribed.
-`prefetch` |*object*.  The FHIR data that was prefetched by the EHR (see more information below)
-
-#### hookInstance
-
-While working in the EHR, a user can perform multiple actions in series or in parallel. For example, a clinician might prescribe two drugs in a row; each prescription action would be assigned a unique `hookInstance`. This allows a CDS Service to uniquely identify each hook invocation.
-
-Note: the `hookInstance` is globally unique and should contain enough entropy to be un-guessable.
 
 #### Providing FHIR Resources to the CDS Service
 


### PR DESCRIPTION
1) Moved the example JSON to follow the specification
2) Added priorities to the HTTP request fields table.  NOTE:  We discussed the fact that aud should not be included in the fhirAuthorization structure because fhirServer was specified outside the fhirAuthorization structure.  However, a dependency exists between the two:  if fhirAuthorization is included, a fhirServer MUST be specified.  I've made them both OPTIONAL here, and noted that if fhirAuthorization is included, fhirServer is REQUIRED.  It might be cleaner to put fhirServer inside the fhirAuthorization structure so that fhirAuthorization could be OPTIONAL, but fhirServer (as a parameter of fhirAuthorization) could be REQUIRED.