### PR TITLE
Add reference to Hooks page where context is described more fully

### DIFF
--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -111,7 +111,7 @@ Field | Priority | Description
 `fhirServer` | OPTIONAL | *URL*.  The base URL EHR's [FHIR](https://www.hl7.org/fhir/) server. If fhirAuthorization is provided, this field is REQUIRED.  The scheme should be `https`
 `fhirAuthorization` | OPTIONAL | *object*. A structure holding an OAuth 2.0 bearer access token granting the CDS Service access to FHIR resources, along with supplemental information relating to the token. See the [FHIR Resource Access](#fhir-resource-access) section for more information.
 `user` | REQUIRED | *string*.  The FHIR resource type + id representing the current user.<br />The type is one of: [Practitioner](https://www.hl7.org/fhir/practitioner.html), [Patient](https://www.hl7.org/fhir/patient.html), or [RelatedPerson](https://www.hl7.org/fhir/relatedperson.html).<br />For example, `Practitioner/123`
-`context` | REQUIRED | *object*.  Hook-specific contextual data that the CDS service will need.<br />For example, with the `medication-prescribe` hook this will include [MedicationOrder](https://www.hl7.org/fhir/medicationorder.html) being prescribed.
+`context` | REQUIRED | *object*.  Hook-specific contextual data that the CDS service will need.<br />For example, with the `medication-prescribe` hook this will include [MedicationOrder](https://www.hl7.org/fhir/medicationorder.html) being prescribed.  For details, see the [Hooks specification](http://cds-hooks.org/hooks/).
 `prefetch` | OPTIONAL | *object*.  The FHIR data that was prefetched by the EHR (see more information below)
 
 #### hookInstance


### PR DESCRIPTION
Because "context" is included in the HTTP call to invoke a CDS Service, developers will need to know its contents.  Added reference to the Hooks specification, where "context" is defined.