### PR TITLE
Update dependencies & remove Gemnasium

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 # CDS Hooks
 
 [![Build Status](https://api.travis-ci.org/cds-hooks/docs.svg)](https://travis-ci.org/cds-hooks/docs)
-[![Dependencies Status](http://img.shields.io/gemnasium/cds-hooks/docs.svg)](https://gemnasium.com/cds-hooks/docs)
 
 CDS Hooks is a vendor agnostic remote decision support standard. This repository serves as both the specification and website for the CDS Hooks project.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 backports-abc==0.5
-certifi==2017.11.5
+certifi==2018.1.18
 click==6.7
 Jinja2==2.10
 livereload==2.5.1
@@ -10,4 +10,4 @@ PyYAML==3.12
 singledispatch==3.4.0.3
 six==1.11.0
 tornado==4.5.3
-mkdocs-material==2.5.4
+mkdocs-material==2.6.2


### PR DESCRIPTION
- Uplift to the latest mkdocs-material and certifi
- Remove Gemnasium as this service is being EOL / shut down in a few months (see [this blog](https://gemnasium.com/blog/gemnasium-is-acquired-by-gitlab/))