### PR TITLE
Document how the JWK Set is communicated (fixes #87)

### DIFF
--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -524,9 +524,10 @@ An example JSON web token header and payload:
 
 ```json
 {
-  "alg": "HS256",
+  "alg": "ES384",
   "typ": "JWT",
-  "kid": "example-kid"
+  "kid": "example-kid",
+  "jku": "https://fhir-ehr.example.com/jwk_uri"
 }
 
 {
@@ -542,7 +543,7 @@ An example JSON web token header and payload:
 Using the above JWT payload, the complete JWT as passed in the Authorization HTTP header would be:
 
 ```
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImV4YW1wbGUta2lkIn0.eyJpc3MiOiJodHRwczovL2ZoaXItZWhyLmV4YW1wbGUuY29tLyIsImF1ZCI6Imh0dHBzOi8vY2RzLmV4YW1wbGUub3JnL2Nkcy1zZXJ2aWNlcy9zb21lLXNlcnZpY2UiLCJleHAiOjE0MjI1Njg4NjAsImlhdCI6MTMxMTI4MDk3MCwianRpIjoiZWUyMmIwMjEtZTFiNy00NjExLWJhNWItOGVlYzZhMzNhYzFlIn0.ATQ_bdiMFrKQMz2U-rALxzakOrBSEMtzTtMcDeXiF74
+Authorization: Bearer eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCIsImtpZCI6ImV4YW1wbGUta2lkIiwiamt1IjoiaHR0cHM6Ly9maGlyLWVoci5leGFtcGxlLmNvbS9qd2tfdXJpIn0.eyJpc3MiOiJodHRwczovL2ZoaXItZWhyLmV4YW1wbGUuY29tLyIsInN1YiI6ImNsaWVudF9pZCIsImF1ZCI6Imh0dHBzOi8vY2RzLmV4YW1wbGUub3JnL2Nkcy1zZXJ2aWNlcy9zb21lLXNlcnZpY2UiLCJleHAiOjE0MjI1Njg4NjAsImlhdCI6MTMxMTI4MDk3MCwianRpIjoiZWUyMmIwMjEtZTFiNy00NjExLWJhNWItOGVlYzZhMzNhYzFlIn0.230VxOubItskK-HCzdfjR5Y76nEydquQoqK-JDHbl8y8wzo-7HJetYpY1R4rytp_yJJCc8DULX9G5llPKx6opQ
 ```
 
 ### Cross-Origin Resource Sharing

--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -512,7 +512,7 @@ exp | REQUIRED | *number* | Expiration time integer for this authentication JWT,
 iat | REQUIRED | *number* | The time at which this JWT was issued, expressed in seconds since the "Epoch" (1970-01-01T00:00:00Z UTC).
 jti | REQUIRED | *string* | A nonce string value that uniquely identifies this authentication JWT (used to protect against replay attacks)
 
-CDS Services SHOULD use the `iss` field to whitelist EHRs they trust.
+CDS Services SHOULD whitelist the `iss`, `jku` and `sub` fields to only the EHRs they trust.
 
 Per [rfc7519](https://tools.ietf.org/html/rfc7519#section-4.1.3), the `aud` value is either a string or an array of strings. For CDS Hooks, this value MUST BE the URL of the CDS Service endpoint being invoked. For example, consider a CDS Service available at a base URL of `https://cds.example.org`. When the EHR invokes the CDS Service discovery endpoint, the aud value is either `"https://cds.example.org/cds-services"` or `["https://cds.example.org/cds-services"]`. Similarly, when the EHR invokes a particular CDS Service (say, `some-service`), the aud value is either `"https://cds.example.org/cds-services/some-service"` or `["https://cds.example.org/cds-services/some-service"]`.
 

--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -509,8 +509,8 @@ iss | REQUIRED | *string* | The URI of the issuer of this JWT.  Note that the JW
 sub | REQUIRED | *string* | Client_id of the EHR.
 aud | REQUIRED | *string* or *array of string* | The CDS Service endpoint that is being called by the EHR. (See more details below).
 exp | REQUIRED | *number* | Expiration time integer for this authentication JWT, expressed in seconds since the "Epoch" (1970-01-01T00:00:00Z UTC).
-iat | REQUIRED | *number* | The time at which this JWT was issued, expressed in seconds since the "Epoch" (1970-01-01T00:00:00Z UTC). CDS Services SHOULD reject any request with an ita older than 5 minutes.
-jti | REQUIRED | *string* | A nonce string value that uniquely identifies this authentication JWT (used to protect against replay attacks). CDS Services SHOULD reject any request with a jti reused within the last 5 minutes. 
+iat | REQUIRED | *number* | The time at which this JWT was issued, expressed in seconds since the "Epoch" (1970-01-01T00:00:00Z UTC).
+jti | REQUIRED | *string* | A nonce string value that uniquely identifies this authentication JWT (used to protect against replay attacks)
 
 CDS Services SHOULD whitelist the `iss`, `jku` and `sub` fields to only the EHRs they trust.
 

--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -499,21 +499,26 @@ Field | Optionality | Type | Value
 alg | REQUIRED | *string* | The cryptographic algorithm used to sign this JWT.
 kid | REQUIRED | *string* | The identifier of the key-pair used to sign this JWT.
 typ | REQUIRED | *string* | Fixed value: `JWT`.
+jku | OPTIONAL | *url*    | The URL to the JWK Set containing the public key(s).
 
 The JWT payload contains the following fields:
 
 Field | Optionality | Type | Value
 ----- | ----- | ----- | --------
-iss | REQUIRED | *string* | The URL of the issuer of this JWT.  Note that the JWT may be self-issued by the EHR, or may be issued by a third-party identity provider.
+iss | REQUIRED | *string* | The URI of the issuer of this JWT.  Note that the JWT may be self-issued by the EHR, or may be issued by a third-party identity provider.
 sub | REQUIRED | *string* | Client_id of the EHR.
 aud | REQUIRED | *string* or *array of string* | The CDS Service endpoint that is being called by the EHR. (See more details below).
 exp | REQUIRED | *number* | Expiration time integer for this authentication JWT, expressed in seconds since the "Epoch" (1970-01-01T00:00:00Z UTC).
 iat | REQUIRED | *number* | The time at which this JWT was issued, expressed in seconds since the "Epoch" (1970-01-01T00:00:00Z UTC).
 jti | REQUIRED | *string* | A nonce string value that uniquely identifies this authentication JWT (used to protect against replay attacks)
 
+CDS Services SHOULD use the `iss` field to whitelist EHRs they trust.
+
 Per [rfc7519](https://tools.ietf.org/html/rfc7519#section-4.1.3), the `aud` value is either a string or an array of strings. For CDS Hooks, this value MUST BE the URL of the CDS Service endpoint being invoked. For example, consider a CDS Service available at a base URL of `https://cds.example.org`. When the EHR invokes the CDS Service discovery endpoint, the aud value is either `"https://cds.example.org/cds-services"` or `["https://cds.example.org/cds-services"]`. Similarly, when the EHR invokes a particular CDS Service (say, `some-service`), the aud value is either `"https://cds.example.org/cds-services/some-service"` or `["https://cds.example.org/cds-services/some-service"]`.
 
 The EHR MUST make its public key, expressed as a JSON Web Key (JWK) in a JWK Set, as defined by [rfc7517](https://tools.ietf.org/html/rfc7517). The `kid` value from the JWT header allows a CDS Service to identify the correct JWK in the JWK Set that can be used to verify the signature.
+
+The EHR MAY make its JWK Set available via a URL identified by the `jku` header field, as defined by [rfc7517 4.1.2](https://tools.ietf.org/html/rfc7515#page-10). If the `jku` header field is ommitted, the EHR and CDS Service SHALL communicate the JWK Set out-of-band.
 
 An example JSON web token header and payload:
 

--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -497,7 +497,7 @@ The JWT header contains the following fields (see [rfc7515 section 4.1](https://
 Field | Optionality | Type | Value
 ----- | ----- | ----- | --------
 alg | REQUIRED | *string* | The cryptographic algorithm used to sign this JWT.
-kid | REQUIRED | *string* | The identifier of the key-pair used to sign this JWT.
+kid | REQUIRED | *string* | The identifier of the key-pair used to sign this JWT. This identifier MUST be unique within the EHR's JWK Set.
 typ | REQUIRED | *string* | Fixed value: `JWT`.
 jku | OPTIONAL | *url*    | The URL to the JWK Set containing the public key(s).
 

--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -509,8 +509,8 @@ iss | REQUIRED | *string* | The URI of the issuer of this JWT.  Note that the JW
 sub | REQUIRED | *string* | Client_id of the EHR.
 aud | REQUIRED | *string* or *array of string* | The CDS Service endpoint that is being called by the EHR. (See more details below).
 exp | REQUIRED | *number* | Expiration time integer for this authentication JWT, expressed in seconds since the "Epoch" (1970-01-01T00:00:00Z UTC).
-iat | REQUIRED | *number* | The time at which this JWT was issued, expressed in seconds since the "Epoch" (1970-01-01T00:00:00Z UTC).
-jti | REQUIRED | *string* | A nonce string value that uniquely identifies this authentication JWT (used to protect against replay attacks)
+iat | REQUIRED | *number* | The time at which this JWT was issued, expressed in seconds since the "Epoch" (1970-01-01T00:00:00Z UTC). CDS Services SHOULD reject any request with an ita older than 5 minutes.
+jti | REQUIRED | *string* | A nonce string value that uniquely identifies this authentication JWT (used to protect against replay attacks). CDS Services SHOULD reject any request with a jti reused within the last 5 minutes. 
 
 CDS Services SHOULD whitelist the `iss`, `jku` and `sub` fields to only the EHRs they trust.
 

--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -518,7 +518,7 @@ Per [rfc7519](https://tools.ietf.org/html/rfc7519#section-4.1.3), the `aud` valu
 
 The EHR MUST make its public key, expressed as a JSON Web Key (JWK) in a JWK Set, as defined by [rfc7517](https://tools.ietf.org/html/rfc7517). The `kid` value from the JWT header allows a CDS Service to identify the correct JWK in the JWK Set that can be used to verify the signature.
 
-The EHR MAY make its JWK Set available via a URL identified by the `jku` header field, as defined by [rfc7517 4.1.2](https://tools.ietf.org/html/rfc7515#page-10). If the `jku` header field is ommitted, the EHR and CDS Service SHALL communicate the JWK Set out-of-band.
+The EHR MAY make its JWK Set available via a URL identified by the `jku` header field, as defined by [rfc7517 4.1.2](https://tools.ietf.org/html/rfc7515#section-4.1.2). If the `jku` header field is ommitted, the EHR and CDS Service SHALL communicate the JWK Set out-of-band.
 
 An example JSON web token header and payload:
 


### PR DESCRIPTION
In addition to documenting that the JWK Set is communicated either via the standard `jku` header or out-of-band, I relaxed the `iss` value from URL to URI. This is to address deployment scenarios where the issuer cannot be a URL.

Fixes #87 