### PR TITLE
Use GitHub Flavored Markdown for the CDS card detail attribute as-is

### DIFF
--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -351,7 +351,7 @@ Each **Card** is described by the following attributes.
 Field | Optionality | Type | Description
 ----- | ----- | ----- | --------
 `summary` | REQUIRED | *string* | One-sentence, <140-character summary message for display to the user inside of this card.
-`detail` | OPTIONAL | *string* | Optional detailed information to display; if provided MUST BE represented in [(GitHub Flavored) Markdown](https://github.github.com/gfm/) without HTML. (For non-urgent cards, the EHR MAY hide these details until the user clicks a link like "view more details...".)
+`detail` | OPTIONAL | *string* | Optional detailed information to display; if provided MUST BE represented in [(GitHub Flavored) Markdown](https://github.github.com/gfm/). (For non-urgent cards, the EHR MAY hide these details until the user clicks a link like "view more details...".)
 `indicator` | REQUIRED | *string* | Urgency/importance of what this card conveys. Allowed values, in order of increasing urgency, are: `info`, `warning`, `hard-stop`. The EHR MAY use this field to help make UI display decisions such as sort order or coloring. The value `hard-stop` indicates that the workflow should not be allowed to proceed.
 `source` | REQUIRED | *object* | Grouping structure for the **Source** of the information displayed on this card. The source should be the primary source of guidance for the decision support the card represents.
 <nobr>`suggestions`</nobr> | OPTIONAL | *array* of **Suggestions** | Allows a service to suggest a set of changes in the context of the current activity (e.g.  changing the dose of the medication currently being prescribed, for the `medication-prescribe` activity). If used, the user MUST BE allowed to choose no more than one suggestion.


### PR DESCRIPTION
This includes the subset of HTML that GFM allows in its content. Fixes #319 and #355.