### PR TITLE
Clarify that the CDS Hooks APIs use TLS over HTTP (fixes #209 and #210)

### DIFF
--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-The CDS Hooks specification describes the RESTful APIs and interactions between EHRs and CDS Services. All data exchanged through the RESTful APIs MUST BE sent and received as JSON structures, and MUST be transmitted over channels secured using Transport Layer Security (TLS) over the Hypertext Transfer Protocol (HTTP).
+The CDS Hooks specification describes the RESTful APIs and interactions between EHRs and CDS Services. All data exchanged through the RESTful APIs MUST BE sent and received as JSON structures, and MUST be transmitted over channels secured using the Hypertext Transfer Protocol (HTTP) over Transport Layer Security (TLS), also known as HTTPS and defined in [RFC2818](https://tools.ietf.org/html/rfc2818).
 
 ### Conformance Language
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this specification are to be interpreted as described in [RFC2119](https://tools.ietf.org/html/rfc2119).

--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-The CDS Hooks specification describes the RESTful APIs and interactions between EHRs and CDS Services. All data exchanged through the RESTful APIs MUST BE sent and received as JSON structures, and MUST be transmitted over channels secured using Transport Layer Security (TLS).
+The CDS Hooks specification describes the RESTful APIs and interactions between EHRs and CDS Services. All data exchanged through the RESTful APIs MUST BE sent and received as JSON structures, and MUST be transmitted over channels secured using Transport Layer Security (TLS) over the Hypertext Transfer Protocol (HTTP).
 
 ### Conformance Language
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this specification are to be interpreted as described in [RFC2119](https://tools.ietf.org/html/rfc2119).


### PR DESCRIPTION
Additionally, a reference to [rfc2818](https://tools.ietf.org/html/rfc2818) was added to fix #210