### PR TITLE
organization-specific hooks SHALL use reverse-DNS

### DIFF
--- a/docs/hooks/index.md
+++ b/docs/hooks/index.md
@@ -91,7 +91,7 @@ Hooks are defined in the following format.
 
 ### `hook-name-expressed-as-noun-verb`
 
-The name of the hook SHOULD succinctly and clearly describe the activity or event. Hook names are unique so hook creators SHOULD take care to ensure newly proposed hooks do not conflict with an existing hook name. Hook creators MAY choose to name their hook with a URI (e.g. `https://example.org/hooks/patient-transmogrify`) if the hook is specific to an organization.
+The name of the hook SHOULD succinctly and clearly describe the activity or event. Hook names are unique so hook creators SHOULD take care to ensure newly proposed hooks do not conflict with an existing hook name. Hook creators SHALL name their hook with reverse domain notation (e.g. `org.example.patient-transmogrify`) if the hook is specific to an organization. Reverse domain notation SHALL not be used by a standard hooks catalog.
 
 When naming hooks, the name should start with the subject (noun) of the hook and be followed by the activity (verb). For example, `patient-view` (not `view-patient`) or `medication-prescribe` (not `prescribe-medication`).
 


### PR DESCRIPTION
Organization-specific hooks SHALL use reverse domain name notation.

Fixes #335.