### PR TITLE
Specify context resources are in draft status for the medication-prescribe and order-review hooks

### DIFF
--- a/docs/hooks/medication-prescribe.md
+++ b/docs/hooks/medication-prescribe.md
@@ -11,7 +11,7 @@ The user is in the process of prescribing one or more new medications.
 
 ## Context
 
-The set of medications proposed or in progress of being prescribed. All FHIR resources in this context MUST be based on the same FHIR version.
+The set of medications proposed or in progress of being prescribed. All FHIR resources in this context MUST be based on the same FHIR version. All FHIR resources in the medications object MUST have a status of _draft_.
 
 Field | Optionality | Prefetch Token | Type | Description
 ----- | -------- | ---- | ---- | ----

--- a/docs/hooks/medication-prescribe.md
+++ b/docs/hooks/medication-prescribe.md
@@ -17,7 +17,7 @@ Field | Optionality | Prefetch Token | Type | Description
 ----- | -------- | ---- | ---- | ----
 `patientId` | REQUIRED | Yes | *string* |  The FHIR `Patient.id` of the current patient in context
 `encounterId` | OPTIONAL | Yes | *string* |  The FHIR `Encounter.id` of the current encounter in context
-`medications` | REQUIRED | No | *object* | DSTU2 - FHIR Bundle of _draft_ MedicationOrder resources <br/> STU3 - FHIR Bundle of _draft_ MedicationOrder resources
+`medications` | REQUIRED | No | *object* | DSTU2 - FHIR Bundle of _draft_ MedicationOrder resources <br/> STU3 - FHIR Bundle of _draft_ MedicationRequest resources
 
 ### Example (DSTU2)
 

--- a/docs/hooks/medication-prescribe.md
+++ b/docs/hooks/medication-prescribe.md
@@ -17,7 +17,7 @@ Field | Optionality | Prefetch Token | Type | Description
 ----- | -------- | ---- | ---- | ----
 `patientId` | REQUIRED | Yes | *string* |  The FHIR `Patient.id` of the current patient in context
 `encounterId` | OPTIONAL | Yes | *string* |  The FHIR `Encounter.id` of the current encounter in context
-`medications` | REQUIRED | No | *object* | DSTU2 - FHIR Bundle of MedicationOrder resources <br/> STU3 - FHIR Bundle of MedicationOrder
+`medications` | REQUIRED | No | *object* | DSTU2 - FHIR Bundle of _draft_ MedicationOrder resources <br/> STU3 - FHIR Bundle of _draft_ MedicationOrder resources
 
 ### Example (DSTU2)
 

--- a/docs/hooks/order-review.md
+++ b/docs/hooks/order-review.md
@@ -11,7 +11,7 @@ The user is in the process of reviewing a set of orders to sign.
 
 ## Context
 
-The set of orders being reviewed for signature on-screen. All FHIR resources in this _context_ MUST be based on the same FHIR version. All FHIR resources in the medications object MUST have a status of _draft_
+The set of orders being reviewed for signature on-screen. All FHIR resources in this _context_ MUST be based on the same FHIR version. All FHIR resources in the medications object MUST have a status of _draft_.
 
 Field | Optionality | Prefetch Token | Type | Description
 ----- | -------- | ---- | ---- | ----

--- a/docs/hooks/order-review.md
+++ b/docs/hooks/order-review.md
@@ -11,13 +11,13 @@ The user is in the process of reviewing a set of orders to sign.
 
 ## Context
 
-The set of orders being reviewed for signature on-screen. All FHIR resources in this _context_ MUST be based on the same FHIR version.
+The set of orders being reviewed for signature on-screen. All FHIR resources in this _context_ MUST be based on the same FHIR version. All FHIR resources in the medications object MUST have a status of _draft_
 
 Field | Optionality | Prefetch Token | Type | Description
 ----- | -------- | ---- | ---- | ----
 `patientId` | REQUIRED | Yes | *string* | The FHIR `Patient.id` of the current patient in context
 `encounterId` | OPTIONAL | Yes | *string* | The FHIR `Encounter.id` of the current encounter in context
-`orders` | REQUIRED | No | *object* | DSTU2 - FHIR Bundle of MedicationOrder, DiagnosticOrder, DeviceUseRequest, ReferralRequest, ProcedureRequest, NutritionOrder, VisionPrescription <br/> STU3 - FHIR Bundle of MedicationRequest, ReferralRequest, ProcedureRequest, NutritionOrder, VisionPrescription
+`orders` | REQUIRED | No | *object* | DSTU2 - FHIR Bundle of MedicationOrder, DiagnosticOrder, DeviceUseRequest, ReferralRequest, ProcedureRequest, NutritionOrder, VisionPrescription with _draft_ status <br/> STU3 - FHIR Bundle of MedicationRequest, ReferralRequest, ProcedureRequest, NutritionOrder, VisionPrescription with _draft_ status
 
 ### Example (DSTU2)
 


### PR DESCRIPTION
Fixes #329 

I'm not updating the version of the hook, because I'm considering the completion of the HL7 ballot to be the beginning of 1.0. Also, this is a clarification, not necessarily a change.