### PR TITLE
link to MedRequest, not MedOrder

### DIFF
--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -112,7 +112,7 @@ Field | Optionality | Type | Description
 `fhirServer` | OPTIONAL | *URL* | The base URL EHR's [FHIR](https://www.hl7.org/fhir/) server. If fhirAuthorization is provided, this field is REQUIRED.  The scheme should be `https`
 `fhirAuthorization` | OPTIONAL | *object* | A structure holding an [OAuth 2.0][OAuth 2.0] bearer access token granting the CDS Service access to FHIR resources, along with supplemental information relating to the token. See the [FHIR Resource Access](#fhir-resource-access) section for more information.
 `user` | REQUIRED | *string* | The FHIR resource type + id representing the current user.<br />The type is one of: [Practitioner](https://www.hl7.org/fhir/practitioner.html), [Patient](https://www.hl7.org/fhir/patient.html), or [RelatedPerson](https://www.hl7.org/fhir/relatedperson.html).<br />For example, `Practitioner/123`
-`context` | REQUIRED | *object* | Hook-specific contextual data that the CDS service will need.<br />For example, with the `medication-prescribe` hook this will include [MedicationRequest](https://www.hl7.org/fhir/medicationrequest.html) being prescribed.  For details, see the Hooks specification page.
+`context` | REQUIRED | *object* | Hook-specific contextual data that the CDS service will need.<br />For example, with the `patient-view` hook this will include the FHIR identifier of the [Patient](https://www.hl7.org/fhir/patient.html) being viewed.  For details, see the Hooks specification page.
 `prefetch` | OPTIONAL | *object* | The FHIR data that was prefetched by the EHR (see more information below)
 
 #### hookInstance

--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -89,7 +89,7 @@ curl "https://example.com/cds-services"
       "id": "medication-echo",
       "prefetch": {
         "patient": "Patient/{{context.patientId}}",
-        "medications": "MedicationOrder?patient={{context.patientId}}"
+        "medications": "MedicationRequest?patient={{context.patientId}}"
       }
     }
   ]
@@ -113,7 +113,7 @@ Field | Optionality | Type | Description
 `fhirServer` | OPTIONAL | *URL* | The base URL EHR's [FHIR](https://www.hl7.org/fhir/) server. If fhirAuthorization is provided, this field is REQUIRED.  The scheme should be `https`
 `fhirAuthorization` | OPTIONAL | *object* | A structure holding an [OAuth 2.0][OAuth 2.0] bearer access token granting the CDS Service access to FHIR resources, along with supplemental information relating to the token. See the [FHIR Resource Access](#fhir-resource-access) section for more information.
 `user` | REQUIRED | *string* | The FHIR resource type + id representing the current user.<br />The type is one of: [Practitioner](https://www.hl7.org/fhir/practitioner.html), [Patient](https://www.hl7.org/fhir/patient.html), or [RelatedPerson](https://www.hl7.org/fhir/relatedperson.html).<br />For example, `Practitioner/123`
-`context` | REQUIRED | *object* | Hook-specific contextual data that the CDS service will need.<br />For example, with the `medication-prescribe` hook this will include [MedicationOrder](https://www.hl7.org/fhir/medicationorder.html) being prescribed.  For details, see the [Hooks specification](http://cds-hooks.org/hooks/).
+`context` | REQUIRED | *object* | Hook-specific contextual data that the CDS service will need.<br />For example, with the `medication-prescribe` hook this will include [MedicationRequest](https://www.hl7.org/fhir/medicationrequest.html) being prescribed.  For details, see the [Hooks specification](http://cds-hooks.org/hooks/).
 `prefetch` | OPTIONAL | *object* | The FHIR data that was prefetched by the EHR (see more information below)
 
 #### hookInstance


### PR DESCRIPTION
Fixes #308.
The issue is that the link to FHIR's MedicationOrder resource no longer resolved. This is because from DSTU2->STU3, FHIR changed the name of this resource from MedicationOrder to MedicationRequest. Instead of pointing to the DSTU2 MedicationOrder resource, I updated the example and link to point to MedicationRequest.