### PR TITLE
Remove formal MUST language

### DIFF
--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -475,7 +475,7 @@ Once a CDS Service provider is selected, the EHR vendor/provider negotiates the 
 
 Every interaction between an EHR and a CDS Service is initiated by the EHR sending a service request to a CDS Service endpoint protected using the [Transport Layer Security protocol](https://tools.ietf.org/html/rfc5246).   Through the TLS protocol the identity of the CDS Service is authenticated, and an encrypted transmission channel is established between the EHR and the CDS Service. Both the Discovery endpoint and individual CDS Service endpoints are TLS secured.
 
-The EHR’s authorization server is responsible for enforcing restrictions on the CDS Services that may be called and the scope of the FHIR resources that may be prefetched or retrieved from the FHIR server.  Therefore, all CDS Services to be called from within an EHR system MUST BE pre-registered with the authorization server of that EHR.  Pre-registration MUST include registering a CDS client identifier, and agreeing upon the scope of FHIR access that is minimally necessary to provide the clinical decision support required.
+The EHR’s authorization server is responsible for enforcing restrictions on the CDS Services that may be called and the scope of the FHIR resources that may be prefetched or retrieved from the FHIR server.  Therefore, all CDS Services to be called from within an EHR system are pre-registered with the authorization server of that EHR.  Pre-registration includes registering a CDS client identifier, and agreeing upon the scope of FHIR access that is minimally necessary to provide the clinical decision support required.
 
 ### Trusting EHRs
 


### PR DESCRIPTION
Remove formal requirement level language from description of a process that is out of scope of the actual specification.
Fixes #268