### PR TITLE
link to the hooks specification correctly.

### DIFF
--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -50,7 +50,7 @@ Each CDS Service is described by the following attributes.
 
 Field | Optionality | Type | Description
 ----- | ----- | ----- | ---------
-`hook`| REQUIRED | *string* | The hook this service should be invoked on. See [Hook Catalog](#hook-catalog)
+`hook`| REQUIRED | *string* | The hook this service should be invoked on. See [Hooks](../hooks/index.md).
 `title`| RECOMMENDED | *string* | The human-friendly name of this service
 <nobr>`description`</nobr>| REQUIRED | *string* | The description of this service
 `id` | REQUIRED | *string* | The {id} portion of the URL to this service which is available at<br />`{baseUrl}/cds-services/{id}`
@@ -110,7 +110,7 @@ Field | Optionality | Type | Description
 `fhirServer` | OPTIONAL | *URL* | The base URL EHR's [FHIR](https://www.hl7.org/fhir/) server. If fhirAuthorization is provided, this field is REQUIRED.  The scheme should be `https`
 `fhirAuthorization` | OPTIONAL | *object* | A structure holding an [OAuth 2.0][OAuth 2.0] bearer access token granting the CDS Service access to FHIR resources, along with supplemental information relating to the token. See the [FHIR Resource Access](#fhir-resource-access) section for more information.
 `user` | REQUIRED | *string* | The FHIR resource type + id representing the current user.<br />The type is one of: [Practitioner](https://www.hl7.org/fhir/practitioner.html), [Patient](https://www.hl7.org/fhir/patient.html), or [RelatedPerson](https://www.hl7.org/fhir/relatedperson.html).<br />For example, `Practitioner/123`
-`context` | REQUIRED | *object* | Hook-specific contextual data that the CDS service will need.<br />For example, with the `medication-prescribe` hook this will include [MedicationOrder](https://www.hl7.org/fhir/medicationorder.html) being prescribed.  For details, see the [Hooks specification](http://cds-hooks.org/hooks/).
+`context` | REQUIRED | *object* | Hook-specific contextual data that the CDS service will need.<br />For example, with the `medication-prescribe` hook this will include [MedicationOrder](https://www.hl7.org/fhir/medicationorder.html) being prescribed.  For details, see the [Hooks specification](../hooks/index.md).
 `prefetch` | OPTIONAL | *object* | The FHIR data that was prefetched by the EHR (see more information below)
 
 #### hookInstance


### PR DESCRIPTION
Fixes #216 (I think)

Per the [mkdocs relative linking documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#linking-to-pages), I updated two links to the Hooks catalog / specification from broken, relative or fully qualified to relative markdown links.

These links should work in at least three published locations:
1) https://github.com/cds-hooks/docs/blob/master/docs/specification/1.0.md
2) https://cds-hooks.org/specification/1.0/
3) http://cds-hooks.hl7.org/ballots/2018May/specification/1.0/