### PR TITLE
Clarify when the CDS Service can leverage the FHIR server (fixes #247)

### DIFF
--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -289,7 +289,7 @@ To reduce the implementation burden on EHRs that support CDS Services, CDS Hooks
 
 ### FHIR Resource Access
 
-The CDS Service is able to use the EHR's FHIR server to obtain any FHIR resources it requires beyond those provided by the EHR as prefetched data. This is similar to the approach used by SMART on FHIR wherein the SMART app requests and ultimately obtains an access token from the EHR's Authorization server using the SMART launch workflow, as described in [SMART App Authorization Guide](http://docs.smarthealthit.org/authorization/).
+If the EHR provides both `fhirServer` and `fhirAuthorization` request parameters, the CDS Service MAY use the EHR's FHIR server to obtain any FHIR resources it requires beyond those provided by the EHR as prefetched data. This is similar to the approach used by SMART on FHIR wherein the SMART app requests and ultimately obtains an access token from the EHR's Authorization server using the SMART launch workflow, as described in [SMART App Authorization Guide](http://docs.smarthealthit.org/authorization/).
 
 Like SMART on FHIR, CDS Hooks requires that clients present a valid access token to the FHIR server with each API call. Thus, a CDS Service MUST be able to obtain an access token before communicating with the EHR's FHIR resource server. While CDS Hooks shares the underlying technical framework and standards as SMART on FHIR, the CDS Hooks workflow MUST accommodate the automated, low-latency delivery of an access token to the CDS service.
 


### PR DESCRIPTION
This fixes #247 