### PR TITLE
assign maturity to patient-view, med-prescribe, order-review

### DIFF
--- a/docs/hooks/medication-prescribe.md
+++ b/docs/hooks/medication-prescribe.md
@@ -4,7 +4,7 @@
 | ---- | ----
 | specificationVersion | 1.0
 | hookVersion | 1.0
-| Hook maturity | [2 - Tested](specification/1.0/#hook-maturity-model)
+| Hook maturity | [2 - Tested](../../specification/1.0/#hook-maturity-model)
 
 ## Workflow
 

--- a/docs/hooks/medication-prescribe.md
+++ b/docs/hooks/medication-prescribe.md
@@ -4,6 +4,7 @@
 | ---- | ----
 | specificationVersion | 1.0
 | hookVersion | 1.0
+| Hook maturity | [2 - Tested](specification/1.0/#hook-maturity-model)
 
 ## Workflow
 

--- a/docs/hooks/order-review.md
+++ b/docs/hooks/order-review.md
@@ -4,7 +4,7 @@
 | ---- | ----
 | specificationVersion | 1.0
 | hookVersion | 1.0
-| Hook maturity | [1 - Submitted](specification/1.0/#hook-maturity-model)
+| Hook maturity | [1 - Submitted](../../specification/1.0/#hook-maturity-model)
 
 ## Workflow
 

--- a/docs/hooks/order-review.md
+++ b/docs/hooks/order-review.md
@@ -4,7 +4,7 @@
 | ---- | ----
 | specificationVersion | 1.0
 | hookVersion | 1.0
-| Hook maturity | [1 - Submitted](../../specification/1.0/#hook-maturity-model)
+| Hook maturity | [3 - Considered](../../specification/1.0/#hook-maturity-model)
 
 ## Workflow
 

--- a/docs/hooks/order-review.md
+++ b/docs/hooks/order-review.md
@@ -4,6 +4,7 @@
 | ---- | ----
 | specificationVersion | 1.0
 | hookVersion | 1.0
+| Hook maturity | [1 - Submitted](specification/1.0/#hook-maturity-model)
 
 ## Workflow
 

--- a/docs/hooks/patient-view.md
+++ b/docs/hooks/patient-view.md
@@ -4,6 +4,7 @@
 | ---- | ----
 | specificationVersion | 1.0
 | hookVersion | 1.0
+| Hook maturity | [4 - Documented](specification/1.0/#hook-maturity-model)
 
 ## Workflow
 

--- a/docs/hooks/patient-view.md
+++ b/docs/hooks/patient-view.md
@@ -4,7 +4,7 @@
 | ---- | ----
 | specificationVersion | 1.0
 | hookVersion | 1.0
-| Hook maturity | [4 - Documented](specification/1.0/#hook-maturity-model)
+| Hook maturity | [4 - Documented](../../specification/1.0/#hook-maturity-model)
 
 ## Workflow
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,9 +16,9 @@ nav:
     - '1.0': 'specification/1.0.md'
 - Hooks:
     - 'new-hook-template' : 'hooks/template.md'
-    - 'patient-view' : 'hooks/patient-view.md'
-    - 'medication-prescribe' : 'hooks/medication-prescribe.md'
-    - 'order-review' : 'hooks/order-review.md'
+    - 'patient-view 4' : 'hooks/patient-view.md'
+    - 'medication-prescribe 2' : 'hooks/medication-prescribe.md'
+    - 'order-review 1' : 'hooks/order-review.md'
 - Quick Start: 'quickstart.md'
 - Examples: 'examples.md'
 - Community: 'community.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,7 +18,7 @@ nav:
     - 'new-hook-template' : 'hooks/template.md'
     - 'patient-view 4' : 'hooks/patient-view.md'
     - 'medication-prescribe 2' : 'hooks/medication-prescribe.md'
-    - 'order-review 1' : 'hooks/order-review.md'
+    - 'order-review 3' : 'hooks/order-review.md'
 - Quick Start: 'quickstart.md'
 - Examples: 'examples.md'
 - Community: 'community.md'


### PR DESCRIPTION
Fixes #445 

Other than the STU ballot, I think that `patient-view` is ready for CHMM5.

Maturity Level | Maturity title | Requirements
--- | --- | ---
4 | Documented | _The above, and …_ The author agrees that the artifact is sufficiently stable to require implementer consultation for subsequent non-backward compatible changes.  The hook is implemented in the standard CDS Hooks sandbox and multiple prototype projects. The Hook specification SHALL: <ul><ol>Identify a broad set of example contexts in which the hook may be used with a minimum of three, but as many as 8-10.</ol><ol>Clearly differentiate the hook from similar hooks or other standards to help an implementer determine if the hook is correct for their scenario.</ol><ol>Explicitly document example scenarios when the hook should not be used.</ol></ul>
5 | Mature | _The above, and ..._ The hook has been implemented in production in at least two CDS clients and three independent CDS services. An HL7 working group ballots the hook and the hook has passed HL7 STU ballot.