### PR TITLE
Fix to prefetch example, for userId

### DIFF
--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -318,7 +318,7 @@ Only the `encounterId` field in this example is eligible to be a prefetch token 
   "prefetch": {
     "patient": "Patient/{{context.patientId}}",
     "hemoglobin-a1c": "Observation?patient={{context.patientId}}&code=4548-4&_count=1&sort:desc=date",
-    "user": "Practitioner/{{context.userId}}"
+    "user": "{{context.userId}}"
   }
 }
 ```


### PR DESCRIPTION
Fixes #410 

The `context.userId` field is (somewhat recently) defined to contains the FHIR resource name and identifier. For example, this field should contain: `Practitioner/123`. This was done to explicitly support scenarios other than provider-facing, for example, the user could be `Patient/456' or `Person/789` (following the [user-to-FHIR mapping](https://github.com/smart-on-fhir/smart-on-fhir.github.io/issues/148)) that SMART negotiated.

Because of this change, the prefetch example of `Practitioner/{{context.userId}}` would translate into `Practitioner/Practitioner/123` as issue #410 points out. 

This PR simply removes the "Practitioner/" string from the example, in lieu of the alternative, breaking changes suggested in #410.