### PR TITLE
Deprecate medication-prescribe and order-review

### DIFF
--- a/docs/hooks/medication-prescribe.md
+++ b/docs/hooks/medication-prescribe.md
@@ -9,7 +9,7 @@
 
 ## Deprecation Notice
 
-This hooks is being deprecated in favor of the `order-select` and `order-sign` hooks. The workflow during which this hook fires is unclear and has led to varying implementations and confusion. Also, this hook does not allow for procedure orders even though the workflow usually includes both medication and procedure orders. Therefore, after discussions on Zulip, and the HL7 CDS Committee, the `medication-prescribe` and `order-review` hooks are being deprecated in favor of newly created [`order-select`](../order-select) and [`order-sign`](../order-sign) hooks. Native criteria within the EHR will be relied upon to only fire the new hooks for appropriate medications / procedures. This notice is a placeholder to this effect while CDS Hooks determines the [appropriate process for deprecating hooks](https://github.com/cds-hooks/docs/issues/433).
+This hook is deprecated in favor of the `order-select` and `order-sign` hooks, with the goal of  clarifying workflow trigger points and supporting orders beyond medications. In this refactoring, `medication-prescribe` and `order-review` hooks are being deprecated in favor of newly created [`order-select`](../order-select) and [`order-sign`](../order-sign) hooks. This notice is a placeholder to this effect while CDS Hooks determines the [appropriate process for deprecating hooks](https://github.com/cds-hooks/docs/issues/433).
 
 ## Workflow
 

--- a/docs/hooks/medication-prescribe.md
+++ b/docs/hooks/medication-prescribe.md
@@ -6,6 +6,11 @@
 | hookVersion | 1.0
 | Hook maturity | [2 - Tested](../../specification/1.0/#hook-maturity-model)
 
+
+## Deprecation Notice
+
+This hooks is being deprecated in favor of the `order-select` and `order-sign` hooks. The workflow during which this hook fires is unclear and has led to varying implementations and confusion. Also, this hook does not allow for procedure orders even though the workflow usually includes both medication and procedure orders. Therefore, after discussions on Zulip, and the HL7 CDS Committee, the `medication-prescribe` and `order-review` hooks are being deprecated in favor of newly created [`order-select`](../order-select) and [`order-sign`](../order-sign) hooks. Native criteria within the EHR will be relied upon to only fire the new hooks for appropriate medications / procedures. This notice is a placeholder to this effect while CDS Hooks determines the [appropriate process for deprecating hooks](https://github.com/cds-hooks/docs/issues/433).
+
 ## Workflow
 
 The user is in the process of prescribing one or more new medications.

--- a/docs/hooks/order-review.md
+++ b/docs/hooks/order-review.md
@@ -8,7 +8,7 @@
 
 ## Deprecation Notice
 
-This hooks is being deprecated in favor of the `order-sign` hook. The workflow during which this hook fires is unclear and has led to varying implementations and confusion. Therefore, after discussions on Zulip, and the HL7 CDS Committee, the `medication-prescribe` and `order-review` hooks are being deprecated in favor of newly created [`order-select`](../order-select) and [`order-sign`](../order-sign) hooks. This notice is a placeholder to this effect while CDS Hooks determines the [appropriate process for deprecating hooks](https://github.com/cds-hooks/docs/issues/433).
+This hooks is being deprecated in favor of the `order-sign` hook. The workflow during which this hook fires is unclear and has led to varying implementations and confusion. Therefore, after discussions on Zulip, and the HL7 CDS Committee, the `medication-prescribe` and `order-review` hooks are being deprecated in favor of newly created [`order-select`](../order-select) and [`order-sign`](../order-sign) hooks. Native criteria within the EHR will be relied upon to only fire the new hooks for appropriate medications / procedures. This notice is a placeholder to this effect while CDS Hooks determines the [appropriate process for deprecating hooks](https://github.com/cds-hooks/docs/issues/433).
 
 ## Workflow
 

--- a/docs/hooks/order-review.md
+++ b/docs/hooks/order-review.md
@@ -8,7 +8,7 @@
 
 ## Deprecation Notice
 
-This hooks is being deprecated in favor of the `order-sign` hook. The workflow during which this hook fires is unclear and has led to varying implementations and confusion. Therefore, after discussions on Zulip, and the HL7 CDS Committee, the `medication-prescribe` and `order-review` hooks are being deprecated in favor of newly created [`order-select`](../order-select) and [`order-sign`](../order-sign) hooks. Native criteria within the EHR will be relied upon to only fire the new hooks for appropriate medications / procedures. This notice is a placeholder to this effect while CDS Hooks determines the [appropriate process for deprecating hooks](https://github.com/cds-hooks/docs/issues/433).
+This hook is deprecated in favor of the `order-sign` hooks, with the goal of  clarifying workflow trigger points and supporting orders beyond medications. In this refactoring, `medication-prescribe` and `order-review` hooks are being deprecated in favor of newly created [`order-select`](../order-select) and [`order-sign`](../order-sign) hooks. This notice is a placeholder to this effect while CDS Hooks determines the [appropriate process for deprecating hooks](https://github.com/cds-hooks/docs/issues/433).
 
 ## Workflow
 

--- a/docs/hooks/order-review.md
+++ b/docs/hooks/order-review.md
@@ -6,6 +6,10 @@
 | hookVersion | 1.0
 | Hook maturity | [3 - Considered](../../specification/1.0/#hook-maturity-model)
 
+## Deprecation Notice
+
+This hooks is being deprecated in favor of the `order-sign` hook. The workflow during which this hook fires is unclear and has led to varying implementations and confusion. Therefore, after discussions on Zulip, and the HL7 CDS Committee, the `medication-prescribe` and `order-review` hooks are being deprecated in favor of newly created [`order-select`](../order-select) and [`order-sign`](../order-sign) hooks. This notice is a placeholder to this effect while CDS Hooks determines the [appropriate process for deprecating hooks](https://github.com/cds-hooks/docs/issues/433).
+
 ## Workflow
 
 The user is in the process of reviewing a set of orders to sign.

--- a/docs/hooks/order-select.md
+++ b/docs/hooks/order-select.md
@@ -4,6 +4,7 @@
 | ---- | ----
 | specificationVersion | 1.0
 | hookVersion | 1.0
+| Hook maturity | [1 - Submitted](../../specification/1.0/#hook-maturity-model)
 
 ## Workflow
 
@@ -13,6 +14,8 @@ The context of this hook may include defaulted order details
 as it first occurs immediately upon the clinician selecting the order from the order catalogue of the CPOE, or upon her manual selection of order details (e.g. dose, quantity, route, etc). CDS services should expect some of the order information to not yet be specified. 
 Additionally, the context may include previously selected orders that are not yet signed from the same ordering session. 
 The `order-select` hook occurs after the clinician selects the order and before signing. 
+
+This hook is intended to replace (deprecate) the `medication-prescribe` hook. 
 
 ## Context
 

--- a/docs/hooks/order-select.md
+++ b/docs/hooks/order-select.md
@@ -26,7 +26,7 @@ Field | Optionality | Prefetch Token | Type | Description
 `userId` | REQUIRED | Yes | *string* | The id of the current user.<br />For this hook, the user is expected to be of type [Practitioner](https://www.hl7.org/fhir/practitioner.html).<br />For example, `Practitioner/123`
 `patientId` | REQUIRED | Yes | *string* |  The FHIR `Patient.id` of the current patient in context
 `encounterId` | OPTIONAL | Yes | *string* |  The FHIR `Encounter.id` of the current encounter in context
-`selections` | REQUIRED | No| *array* | The FHIR id of the newly selected order(s).<br />The `selections` field references FHIR resources in the `orders` Bundle. For example, `MedicationRequest/103`.
+`selections` | REQUIRED | No| *array* | The FHIR id of the newly selected order(s).<br />The `selections` field references FHIR resources in the `draftOrders` Bundle. For example, `MedicationRequest/103`.
 `draftOrders` | REQUIRED | No | *object* | DSTU2 - FHIR Bundle of MedicationOrder, DiagnosticOrder, DeviceUseRequest, ReferralRequest, ProcedureRequest, NutritionOrder, VisionPrescription with _draft_ status <br/> STU3 - FHIR Bundle of MedicationRequest, ReferralRequest, ProcedureRequest, NutritionOrder, VisionPrescription with _draft_ status
 
 

--- a/docs/hooks/order-sign.md
+++ b/docs/hooks/order-sign.md
@@ -4,7 +4,7 @@
 | ---- | ----
 | specificationVersion | 1.0
 | hookVersion | 1.0
-| Hook maturity | 1 - Submitted
+| Hook maturity | [1 - Submitted](../../specification/1.0/#hook-maturity-model)
 
 ## Workflow
 
@@ -14,7 +14,7 @@ The context contains all order details, such as dose, quantity, route, etc,
 although the order has not yet been signed and therefore still exists in a draft status. 
 Use this hook when your service requires all order details, and the clinician will accept recommended changes.
 
-This hook is intended to replace (deprecate) the `order-review` hook. 
+This hook is intended to replace (deprecate) the `medication-prescribe` and `order-review` hooks. 
 
 ## Context
 


### PR DESCRIPTION
Pull request to deprecate `medication-prescribe` and `order-review` hooks now that `order-select` and `order-sign` hooks have been created.