### PR TITLE
Add logo to spec

### DIFF
--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -1,4 +1,4 @@
-# CDS Services
+![CDS Hooks Overview](../images/logo.png)
 
 !!! info "1.0 Release"
     This is the 1.0 release of the CDS Hooks specification. All releases are available at [https://cds-hooks.hl7.org](https://cds-hooks.hl7.org).


### PR DESCRIPTION
This is a step toward satisfying trademark requirements, to show the logo on the official page where the spec is available. (Actually, I think it looks good too.)