### PR TITLE
Fix 'links' location in Cheat Sheet example

### DIFF
--- a/cheat-sheet/cheat-sheet.md
+++ b/cheat-sheet/cheat-sheet.md
@@ -171,13 +171,13 @@ Field | Optionality | Summary
                         "...": "&ltsnipped for brevity&gt"
                      }
                   }
-               ],
-               "links": [
-                  {
-                     "label": "SMART Example App",
-                     "...": "&ltsnipped for brevity&gt"
-                  }
                ]
+            }
+         ],
+         "links": [
+            {
+               "label": "SMART Example App",
+               "...": "&ltsnipped for brevity&gt"
             }
          ]
       }


### PR DESCRIPTION
Noticed that 'links' was mistakenly placed under 'suggestions'