### PR TITLE
Remove 'sub' from auth token JWT example

### DIFF
--- a/docs/specification/1.0.md
+++ b/docs/specification/1.0.md
@@ -676,7 +676,6 @@ An example JSON web token header, payload, and JWK set:
 // JSON Web Token Payload
 {
   "iss": "https://fhir-ehr.example.com/",
-  "sub": "client_id",
   "aud": "https://cds.example.org/cds-services/some-service",
   "exp": 1422568860,
   "iat": 1311280970,


### PR DESCRIPTION
'sub' was removed from the JWT payload send to CDS Services with the following issue - https://github.com/cds-hooks/docs/issues/356

This PR removes it from a remaining example