### PR TITLE
better indicate that med-prescribe is deprecated

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,7 +17,7 @@ nav:
 - Hooks:
     - 'new-hook-template' : 'hooks/template.md'
     - 'patient-view 4' : 'hooks/patient-view.md'
-    - 'medication-prescribe 2' : 'hooks/medication-prescribe.md'
+    - 'medication-prescribe 🚫' : 'hooks/medication-prescribe.md'
     - 'order-review 🚫' : 'hooks/order-review.md'
     - 'order-select 1' : 'hooks/order-select.md'
     - 'order-sign 1' : 'hooks/order-sign.md'


### PR DESCRIPTION
We already have a deprecation notice on med-prescribe, but indicating so on the menu makes it more clear. 

Related to #433 and following the example set in PR #493.