### PR TITLE
create order-search hook

### DIFF
--- a/docs/hooks/order-search.md
+++ b/docs/hooks/order-search.md
@@ -1,0 +1,53 @@
+# `order-search`
+
+| Metadata | Value
+| ---- | ----
+| specificationVersion | 1.0
+| hookVersion | 1.0
+| hookMaturity | [0 - Draft](../../specification/1.0/#hook-maturity-model)
+
+## Workflow
+
+The `order-search` hook fires when a clinician has decided a patient needs an order (including orders for medications, procedures, labs or other orders), and is searching to find an appropriate one in the order catalogue of the CPOE.
+This hooks is the first workflow event when browsing the catalogue of the CPOE.
+
+The context of this hook must include the type of order that is being searched.
+
+The `order-search` hooks occurs before the `order-select` hook, where a clinician has already selected a specific order but not necessarily the all of the parameters such as how much or how often.
+
+## Context
+
+The `orderType` parameter allows decision services to be run that are appropriate for the current clinical context. There are many types of orders within FHIR and without this additional context a clinician could inadvertently get `DeviceRequest` recommendations while searching for `ServiceRequests`. Prefetch is not an appropriate place for this context because it is optional, and the decision support system may query for additional resources that are not relevant to the current clinical context.
+
+
+Field | Optionality | Prefetch Token | Type | Description
+----- | -------- | ---- | ---- | ----
+`userId` | REQUIRED | Yes | *string* | The id of the current user.<br />For this hook, the user is expected to be of type [Practitioner](https://www.hl7.org/fhir/practitioner.html).<br />For example, `Practitioner/123`
+`patientId` | REQUIRED | Yes | *string* |  The FHIR `Patient.id` of the current patient in context
+`encounterId` | OPTIONAL | Yes | *string* |  The FHIR `Encounter.id` of the current encounter in context
+`orderType` | REQUIRED | No | *string* | The FHIR Resource type of the current search. For example, `DeviceRequest`
+
+### Examples
+
+```json
+"context":{
+  "userId": "Practitioner/123",
+  "patientId" : "1288992",
+  "orderType" : "MedicationRequest"
+}
+```
+
+```json
+"context":{
+  "userId": "Practitioner/123",
+  "patientId" : "1288992",
+  "encounterId" : "456",
+  "orderType": "ServiceRequest"
+}
+```
+
+## Change Log
+
+Version | Description
+---- | ----
+1.0 | Initial Release

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ nav:
     - 'patient-view 4' : 'hooks/patient-view.md'
     - 'medication-prescribe 🚫' : 'hooks/medication-prescribe.md'
     - 'order-review 🚫' : 'hooks/order-review.md'
+    - 'order-search 0' : 'hooks/order-search.md'
     - 'order-select 1' : 'hooks/order-select.md'
     - 'order-sign 1' : 'hooks/order-sign.md'
     - 'appointment-book 1' : 'hooks/appointment-book.md'


### PR DESCRIPTION
This PR contains a proposal for a new `order-search` hook which would be the first hook fired when a clinician is browsing the catalogue of a CPOE. The allows recommendations for specific orders to be made to the clinician by the decision service, or the ability to launch a SMART app that could gather additional information and then subsequently make a recommendation.

This is in contrast to `order-select` in which a specific order has been chosen and further details can be filled out.

The hook defines a `orderType` context parameter to allow only cds services that a relevant to the current type of order to be run. Hypothetically, without this additional context a clinician may be searching for Medications and get Procedures instead, since the definition of "order" is very broad. The order-select hooks is able to avoid this because the selected order that is passed has a specific type, meaning decision services that apply to MedicationRequest selections need not fire if a bundle contains ServiceRequests.

Two other designs were considered in order to achieve the context-specific functionality:

1. Defining a more specific hook that would be <orderType>-search (e.g. medication-search). This runs counter to the current direction of cds-hooks, where type-specific hooks are being retired (such as medication-prescribe).

2. Use a `useContext` resource. This provides a way to convey a very broad range of clinical contexts to the decision service (such as in-patient, out-patient, and the type of issue being treated) but was thought to be too abstract and general making implementation of the hook in EHRs difficult.