### PR TITLE
feedback, MAY for service, SHOULD for client

### DIFF
--- a/docs/specification/current.md
+++ b/docs/specification/current.md
@@ -680,7 +680,7 @@ A `systemAction` is the same **Action** which may be returned in a suggestion, b
 
 ## Feedback
 
-Once a CDS Hooks service responds to a hook by returning a card, the service has no further interaction with the CDS client. The acceptance of a suggestion or rejection of a card is valuable information to enable a service to improve its behavior towards the goal of the end-user having a positive and meaningful experience with the CDS. A feedback endpoint enables suggestion tracking & analytics.
+Once a CDS Hooks service responds to a hook by returning a card, the service has no further interaction with the CDS client. The acceptance of a suggestion or rejection of a card is valuable information to enable a service to improve its behavior towards the goal of the end-user having a positive and meaningful experience with the CDS. A feedback endpoint enables suggestion tracking & analytics. A CDS Service MAY support a feedback endpoint; a CDS Client SHOULD be capable of sending feedback.
 
 Upon receiving a card, a user may accept its suggestions, ignore it entirely, or dismiss it with or without an override reason. Note that while one or more suggestions can be accepted, an entire card is either ignored or overridden.
 


### PR DESCRIPTION
> A CDS Service MAY support a feedback endpoint; a CDS Client SHOULD be capable of sending feedback.

Fixes [FHIR-28683](https://jira.hl7.org/browse/FHIR-28683)