### PR TITLE
minimal change to example override comment

### DIFF
--- a/docs/specification/current.md
+++ b/docs/specification/current.md
@@ -776,7 +776,7 @@ POST {baseUrl}/cds-services/{serviceId}/feedback
 	 		"code":"d7ecf885",
      			"system":"https://example.com/cds-hooks/override-reason-system"
 		},
-		"userComment" : "clinician entered comment"
+		"userComment" : "A comment entered by the clinician."
 	},
          "outcomeTimestamp": "2020-12-11T00:00:00Z"
       }]


### PR DESCRIPTION
Fixes [FHIR-28688](https://jira.hl7.org/browse/FHIR-28688)
>"A comment entered by the clinician."
isntead of:
>"clinician entered comment"