### PR TITLE
fix formatting of json blocks in examples.md

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -185,7 +185,8 @@ This example is taken from the [Opioid Prescribing Support Implementation Guide]
       ]
     }
   }
-}```
+}
+```
 
 > CDS Service Response
 


### PR DESCRIPTION
One of the json blocks did not properly close its backticks, so the following text blocks were being rendered as json.

<img width="1513" alt="Screenshot 2023-05-15 at 12 30 08" src="https://github.com/cds-hooks/docs/assets/9078954/d8317d8c-ce0d-4a08-95fd-9129dcb642dc">
