### PR TITLE
order-dispatch to maturity 1

### DIFF
--- a/docs/hooks/order-dispatch.md
+++ b/docs/hooks/order-dispatch.md
@@ -4,7 +4,7 @@
 | ---- | ----
 | specificationVersion | 2.0
 | hookVersion | 1.1
-| hookMaturity | [0 - Draft](../../specification/current/#hook-maturity-model)
+| hookMaturity | [1 - Submitted](../../specification/current/#hook-maturity-model)
 
 ## Workflow
 


### PR DESCRIPTION
The act of publishing the description of the hook, effectively takes it to 1.

Also, this hook was balloted in the Hook Maturity ballot, and therefore should be published by hl7 at 1.