### PR TITLE
Fix broken link in quickstart.md

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -176,4 +176,4 @@ For some CDS Services the end step will just display the card. For the patient-v
 
 ## Test with external CDS Service
 
-No development is complete without testing with a CDS Service provider. Find a member in the [community](community) and test away. 
+No development is complete without testing with a CDS Service provider. Find a member in the [community](/community) and test away. 


### PR DESCRIPTION
There was a link to the community page that wasn't prepended by a forward slash, so the browser made the link relative to the quickstart page instead of relative to the site.